### PR TITLE
feat: add cloudrunner.WithGRPCServerOptions

### DIFF
--- a/dialservice.go
+++ b/dialservice.go
@@ -11,7 +11,7 @@ import (
 
 // DialService dials another service using the default service account's Google ID Token authentication.
 func DialService(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	runCtx, ok := getRunContext(ctx)
+	run, ok := getRunContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("cloudrunner.DialService %s: must be called with a context from cloudrunner.Run", target)
 	}
@@ -20,11 +20,11 @@ func DialService(ctx context.Context, target string, opts ...grpc.DialOption) (*
 		target,
 		append(
 			[]grpc.DialOption{
-				grpc.WithDefaultServiceConfig(runCtx.runConfig.Client.AsServiceConfigJSON()),
+				grpc.WithDefaultServiceConfig(run.config.Client.AsServiceConfigJSON()),
 				grpc.WithChainUnaryInterceptor(
 					otelgrpc.UnaryClientInterceptor(),
-					runCtx.requestLoggerMiddleware.GRPCUnaryClientInterceptor,
-					runCtx.clientMiddleware.GRPCUnaryClientInterceptor,
+					run.requestLoggerMiddleware.GRPCUnaryClientInterceptor,
+					run.clientMiddleware.GRPCUnaryClientInterceptor,
 				),
 				grpc.WithBlock(),
 			},

--- a/grpcserver.go
+++ b/grpcserver.go
@@ -12,31 +12,31 @@ import (
 
 // NewGRPCServer creates a new gRPC server preconfigured with middleware for request logging, tracing, etc.
 func NewGRPCServer(ctx context.Context, opts ...grpc.ServerOption) *grpc.Server {
-	runCtx, ok := getRunContext(ctx)
+	run, ok := getRunContext(ctx)
 	if !ok {
 		panic("cloudrunner.NewGRPCServer: must be called with a context from cloudrunner.Run")
 	}
 	serverOptions := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			otelgrpc.UnaryServerInterceptor(),
-			runCtx.loggerMiddleware.GRPCUnaryServerInterceptor,        // adds context logger
-			runCtx.traceMiddleware.GRPCServerUnaryInterceptor,         // needs the context logger
-			runCtx.requestLoggerMiddleware.GRPCUnaryServerInterceptor, // needs to run after trace
-			runCtx.serverMiddleware.GRPCUnaryServerInterceptor,        // needs to run after request logger
+			run.loggerMiddleware.GRPCUnaryServerInterceptor,        // adds context logger
+			run.traceMiddleware.GRPCServerUnaryInterceptor,         // needs the context logger
+			run.requestLoggerMiddleware.GRPCUnaryServerInterceptor, // needs to run after trace
+			run.serverMiddleware.GRPCUnaryServerInterceptor,        // needs to run after request logger
 		),
 	}
-	serverOptions = append(serverOptions, runCtx.grpcServerOptions...)
+	serverOptions = append(serverOptions, run.grpcServerOptions...)
 	serverOptions = append(serverOptions, opts...)
 	return grpc.NewServer(serverOptions...)
 }
 
 // ListenGRPC binds a listener on the configured port and listens for gRPC requests.
 func ListenGRPC(ctx context.Context, grpcServer *grpc.Server) error {
-	runCtx, ok := getRunContext(ctx)
+	run, ok := getRunContext(ctx)
 	if !ok {
 		return fmt.Errorf("cloudrunner.ListenGRPC: must be called with a context from cloudrunner.Run")
 	}
-	address := fmt.Sprintf(":%d", runCtx.runConfig.Service.Port)
+	address := fmt.Sprintf(":%d", run.config.Service.Port)
 	listener, err := (&net.ListenConfig{}).Listen(
 		ctx,
 		"tcp",

--- a/httphandler.go
+++ b/httphandler.go
@@ -15,7 +15,7 @@ type HTTPMiddleware = func(http.Handler) http.Handler
 
 // NewHTTPServer creates a new HTTP server preconfigured with middleware for request logging, tracing, etc.
 func NewHTTPServer(ctx context.Context, handler http.Handler, middlewares ...HTTPMiddleware) *http.Server {
-	runCtx, ok := getRunContext(ctx)
+	run, ok := getRunContext(ctx)
 	if !ok {
 		panic("cloudrunner.NewHTTPServer: must be called with a context from cloudrunner.Run")
 	}
@@ -23,21 +23,21 @@ func NewHTTPServer(ctx context.Context, handler http.Handler, middlewares ...HTT
 		func(handler http.Handler) http.Handler {
 			return otelhttp.NewHandler(handler, "server")
 		},
-		runCtx.loggerMiddleware.HTTPServer,
-		runCtx.traceMiddleware.HTTPServer,
-		runCtx.requestLoggerMiddleware.HTTPServer,
-		runCtx.serverMiddleware.HTTPServer,
+		run.loggerMiddleware.HTTPServer,
+		run.traceMiddleware.HTTPServer,
+		run.requestLoggerMiddleware.HTTPServer,
+		run.serverMiddleware.HTTPServer,
 	}
 	return &http.Server{
-		Addr: fmt.Sprintf(":%d", runCtx.runConfig.Service.Port),
+		Addr: fmt.Sprintf(":%d", run.config.Service.Port),
 		Handler: cloudserver.ChainHTTPMiddleware(
 			handler,
 			append(defaultMiddlewares, middlewares...)...,
 		),
-		ReadTimeout:       runCtx.serverMiddleware.Config.Timeout,
-		ReadHeaderTimeout: runCtx.serverMiddleware.Config.Timeout,
-		WriteTimeout:      runCtx.serverMiddleware.Config.Timeout,
-		IdleTimeout:       runCtx.serverMiddleware.Config.Timeout,
+		ReadTimeout:       run.serverMiddleware.Config.Timeout,
+		ReadHeaderTimeout: run.serverMiddleware.Config.Timeout,
+		WriteTimeout:      run.serverMiddleware.Config.Timeout,
+		IdleTimeout:       run.serverMiddleware.Config.Timeout,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -11,30 +11,30 @@ type Option func(*runContext)
 
 // WithRequestLoggerMessageTransformer configures the request logger with a message transformer.
 func WithRequestLoggerMessageTransformer(transformer func(proto.Message) proto.Message) Option {
-	return func(runCtx *runContext) {
-		runCtx.requestLoggerMiddleware.MessageTransformer = transformer
+	return func(run *runContext) {
+		run.requestLoggerMiddleware.MessageTransformer = transformer
 	}
 }
 
 // WithConfig configures an additional config struct to be loaded.
 func WithConfig(name string, config interface{}) Option {
-	return func(runCtx *runContext) {
-		runCtx.configOptions = append(runCtx.configOptions, cloudconfig.WithAdditionalSpec(name, config))
+	return func(run *runContext) {
+		run.configOptions = append(run.configOptions, cloudconfig.WithAdditionalSpec(name, config))
 	}
 }
 
 // WithOptions configures the run context with a list of options.
 func WithOptions(options []Option) Option {
-	return func(runCtx *runContext) {
+	return func(run *runContext) {
 		for _, option := range options {
-			option(runCtx)
+			option(run)
 		}
 	}
 }
 
 // WithGRPCServerOptions configures the run context with additional default options for NewGRPCServer.
 func WithGRPCServerOptions(grpcServerOptions []grpc.ServerOption) Option {
-	return func(runCtx *runContext) {
-		runCtx.grpcServerOptions = append(runCtx.grpcServerOptions, grpcServerOptions...)
+	return func(run *runContext) {
+		run.grpcServerOptions = append(run.grpcServerOptions, grpcServerOptions...)
 	}
 }

--- a/service.go
+++ b/service.go
@@ -8,11 +8,11 @@ import (
 
 // Service returns the service config for the current context.
 func Service(ctx context.Context) ServiceConfig {
-	runCtx, ok := getRunContext(ctx)
+	run, ok := getRunContext(ctx)
 	if !ok {
 		panic("cloudrunner.Logger must be called with a context from cloudrunner.Run")
 	}
-	return runCtx.runConfig.Service
+	return run.config.Service
 }
 
 // ServiceConfig contains generic service configuration.


### PR DESCRIPTION
For including additional default options to cloudrunner.NewGRPCServer.

Intended to be used together with cloudrunner.WithOptions to include
additional gRPC server options in an options bundle.
