### PR TITLE
feat: remove cloudrunner.WithLogger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -18,11 +18,6 @@ func Logger(ctx context.Context) *zap.Logger {
 	return logger
 }
 
-// WithLogger adds a logger to the current context.
-func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
-	return cloudzap.WithLogger(ctx, logger)
-}
-
 // WithLoggerFields attaches structured fields to a new logger in the returned child context.
 func WithLoggerFields(ctx context.Context, fields ...zap.Field) context.Context {
 	logger, ok := cloudzap.GetLogger(ctx)


### PR DESCRIPTION
Adding a logger to the context manually should not need to be part of
the happy-path top-level API, given that we want to keep the top-level
API small and simple.

For unit tests, or other special-cases, one can use
`cloudzap.WithLogger` or `cloudtesting.WithLogger` from the subpackages.