### PR TITLE
 feat: error if retries are not successfully enabled

### DIFF
--- a/cloudclient/config.go
+++ b/cloudclient/config.go
@@ -40,7 +40,8 @@ type RetryConfig struct {
 	// BackoffMultiplier is the exponential backoff multiplier.
 	BackoffMultiplier float64 `default:"1.3"`
 	// RetryableStatusCodes is the set of status codes which may be retried.
-	RetryableStatusCodes []codes.Code `default:"Unavailable"`
+	// Unknown status codes are retried by default for the sake of retrying Google Cloud HTTP load balancer errors.
+	RetryableStatusCodes []codes.Code `default:"Unavailable,Unknown"`
 }
 
 // AsServiceConfigJSON returns the default method call config as a valid gRPC service JSON config.

--- a/run.go
+++ b/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"os/signal"
 	"syscall"
 
@@ -69,6 +70,13 @@ func Run(fn func(context.Context) error, options ...Option) error {
 	}
 	if err := run.config.Runtime.Autodetect(); err != nil {
 		return fmt.Errorf("cloudrunner.Run: %w", err)
+	}
+	if run.config.Client.Retry.Enabled && os.Getenv("GRPC_GO_RETRY") != "on" {
+		// Keep an eye on gRPC Go client retries and remove this if/when retries are enabled by default.
+		return fmt.Errorf(
+			"cloudrunner.Run: must set GRPC_GO_RETRY=on when enabling client retries (see %s)",
+			"https://github.com/grpc/grpc-go/blob/master/examples/features/retry/README.md",
+		)
 	}
 	if *validate {
 		return nil


### PR DESCRIPTION
The GRPC_GO_RETRY environment variable *must* curretly be set to `"on"`
for retries to be enabled.

By cross-checking this variable with the config to enable client
retries, we exit with an error if the user has tried to enable retries
without setting this flag.