### PR TITLE
feat: add support for specifying tracing probability and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ cloudrunner    PROFILER_ENABLED                     bool                        
 cloudrunner    PROFILER_MUTEXPROFILING              bool
 cloudrunner    PROFILER_ALLOCFORCEGC                bool                            true
 cloudrunner    TRACEEXPORTER_ENABLED                bool                                           true
+cloudrunner    TRACEEXPORTER_TIMEOUT                time.Duration                   10s
+cloudrunner    TRACEEXPORTER_SAMPLEPROBABILITY      float64                         0.01
 cloudrunner    SERVER_TIMEOUT                       time.Duration                   290s
 cloudrunner    SERVER_RECOVERPANICS                 bool                                           true
 cloudrunner    CLIENT_TIMEOUT                       time.Duration                   10s


### PR DESCRIPTION
OpenTelemetry traces every single request by default so we set a default
probability of 1% which is a good production default and also allow
setting the timeout for tracing with a default of 10 seconds
(OpenTelemetry has a default of 5 seconds)
