### PR TITLE
feat: preserve auth errors in cloudrunner.WrapTransient

### DIFF
--- a/clouderror/wrap.go
+++ b/clouderror/wrap.go
@@ -33,7 +33,7 @@ func WrapTransient(err error, msg string) error {
 func WrapTransientCaller(err error, msg string, caller Caller) error {
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() {
-		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Unauthenticated, codes.PermissionDenied:
 			return &wrappedStatusError{status: status.New(s.Code(), msg), err: err, caller: caller}
 		}
 	}

--- a/clouderror/wrap_test.go
+++ b/clouderror/wrap_test.go
@@ -37,6 +37,16 @@ func Test_WrapTransient(t *testing.T) {
 			expectedCode: codes.Unavailable,
 		},
 		{
+			name:         "codes.Unauthenticated",
+			err:          status.Error(codes.Unauthenticated, "transient"),
+			expectedCode: codes.Unauthenticated,
+		},
+		{
+			name:         "codes.PermissionDenied",
+			err:          status.Error(codes.PermissionDenied, "transient"),
+			expectedCode: codes.PermissionDenied,
+		},
+		{
 			name: "wrapped transient",
 			err: Wrap(
 				fmt.Errorf("network unavailable"),


### PR DESCRIPTION
Currently when wrapping errors containing codes `Unauthenticated` and
`PermissionDenied` they're wrapped in `codes.Internal`. These are both
client errors that should be communicated.

Check for these codes and preserve them.