### PR TITLE
http request log levels

### DIFF
--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -235,9 +235,9 @@ func (l *Middleware) statusToLevel(status int) zapcore.Level {
 		return level
 	}
 	switch {
-	case status < 400:
+	case status < http.StatusBadRequest:
 		return zap.DebugLevel
-	case 400 <= status && status < 500:
+	case http.StatusBadRequest <= status && status < http.StatusInternalServerError:
 		return zap.WarnLevel
 	default:
 		return zap.ErrorLevel

--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -239,6 +239,9 @@ func (l *Middleware) statusToLevel(status int) zapcore.Level {
 		return zap.DebugLevel
 	case http.StatusBadRequest <= status && status < http.StatusInternalServerError:
 		return zap.WarnLevel
+	case status == http.StatusGatewayTimeout:
+		// special case for 504 (timeout) to match severity for gRPC status codes
+		return zap.WarnLevel
 	default:
 		return zap.ErrorLevel
 	}


### PR DESCRIPTION
- fix(cloudzap): wrap cores correctly
- README.md: Fix broken link to Zap
- feat(deps): bump to stable version of OpenTelemetry
- feat: remove env requirement for GRPC_GO_RETRY=on
- feat: bump Go to 1.17
- feat(deps): bump more dependencies
- fix(deps): revert otel to v1.0.1
- feat(deps): bump to OpenTelemetry with semconv 1.7.0
- feat: preserve auth errors in cloudrunner.WrapTransient
- feat(cloudpubsub): add subscription as context value
- chore(deps): bump go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
- chore(deps): bump go.opentelemetry.io/otel/sdk from 1.1.0 to 1.2.0
- chore(cloudrequestlog): use http constants for status codes
- fix(cloudrequestlog): match grpc status when logging 504
