### PR TITLE
fix(ci): allow dependabot to make releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "*"
 
+# Allow dependabot to make releases
+permissions:
+  contents: write
+
 jobs:
   make:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I hate red CI crosses :D

![image](https://user-images.githubusercontent.com/1151328/145807187-9babb209-0e5e-4e23-a3fd-e63cbbecc621.png)
