### PR TITLE
feat: allow for serving `gRPC` and `HTTP` on the same port

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.17
 
-require go.einride.tech/sage v0.65.1
+require go.einride.tech/sage v0.66.5

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.65.1 h1:vrmVqfcn1kfb9HIrHuZZfcWSrLE2cwPLeTSbeSQTHFk=
-go.einride.tech/sage v0.65.1/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.66.5 h1:/NTB5iwSn6TPMpLjs1h03g3LmuUiE8f0FOCxRJEbclQ=
+go.einride.tech/sage v0.66.5/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/cloudmux/mux.go
+++ b/cloudmux/mux.go
@@ -1,0 +1,90 @@
+package cloudmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/soheilhy/cmux"
+	"go.einride.tech/cloudrunner"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+)
+
+// ServeGRPCHTTP serves both a gRPC and an HTTP server on listener l.
+// When the context is canceled, the servers will be gracefully shutdown and
+// then the function will return.
+func ServeGRPCHTTP(
+	ctx context.Context,
+	l net.Listener,
+	grpcServer *grpc.Server,
+	httpServer *http.Server,
+) error {
+	m := cmux.New(l)
+	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	httpL := m.Match(cmux.Any())
+	logger := cloudrunner.Logger(ctx)
+
+	var g errgroup.Group
+
+	// wait for context to be canceled and gracefully stop all servers.
+	g.Go(func() error {
+		<-ctx.Done()
+
+		logger.Debug("stopping cmux server")
+		m.Close()
+
+		logger.Debug("stopping HTTP server")
+		// use a new context because the parent ctx is already canceled.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		if err := httpServer.Shutdown(ctx); err != nil && !isClosedErr(err) {
+			logger.Warn("stopping http server", zap.Error(err))
+		}
+
+		logger.Debug("stopping gRPC server")
+		grpcServer.GracefulStop()
+		logger.Debug("stopped both http and grpc server")
+		return nil
+	})
+
+	g.Go(func() error {
+		logger.Debug("serving gRPC")
+		if err := grpcServer.Serve(grpcL); err != nil && !isClosedErr(err) {
+			return fmt.Errorf("serve gRPC: %w", err)
+		}
+		logger.Debug("stopped serving gRPC")
+		return nil
+	})
+
+	g.Go(func() error {
+		logger.Debug("serving HTTP")
+		if err := httpServer.Serve(httpL); err != nil && !isClosedErr(err) {
+			return fmt.Errorf("serve HTTP: %w", err)
+		}
+		logger.Debug("stopped serving HTTP")
+		return nil
+	})
+
+	if err := m.Serve(); err != nil && !isClosedErr(err) {
+		logger.Error("oops", zap.Error(err))
+		return fmt.Errorf("serve cmux: %w", err)
+	}
+	return g.Wait()
+}
+
+func isClosedErr(err error) bool {
+	return isClosedConnErr(err) ||
+		errors.Is(err, http.ErrServerClosed) ||
+		errors.Is(err, cmux.ErrServerClosed) ||
+		errors.Is(err, grpc.ErrServerStopped)
+}
+
+func isClosedConnErr(err error) bool {
+	return strings.Contains(err.Error(), "use of closed network connection")
+}

--- a/cloudmux/mux_test.go
+++ b/cloudmux/mux_test.go
@@ -1,0 +1,209 @@
+package cloudmux
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"go.einride.tech/cloudrunner/cloudzap"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/examples/helloworld/helloworld"
+	"gotest.tools/v3/assert"
+)
+
+func TestServe_Canceled(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		fx.listen()
+		wg.Done()
+	}()
+
+	// wait for server to be ready
+	time.Sleep(time.Millisecond * 20)
+
+	// stop listening
+	fx.stop()
+
+	wg.Wait()
+	assert.NilError(t, fx.lisErr)
+}
+
+func TestServe_GracefulGRPC(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	fx.grpc.latency = time.Second
+	requestConn := make(chan struct{})
+	fx.grpc.requestRecvChan = requestConn
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		fx.listen()
+		wg.Done()
+	}()
+
+	client := greeterClient(t, fx.lis.Addr())
+	var callErr error
+	wg.Add(1)
+	go func() {
+		_, callErr = client.SayHello(context.Background(), &helloworld.HelloRequest{
+			Name: "world",
+		})
+		wg.Done()
+	}()
+
+	// wait for server to have received request
+	<-requestConn
+
+	// stop listening
+	fx.stop()
+
+	wg.Wait()
+	assert.NilError(t, callErr)
+	assert.NilError(t, fx.lisErr)
+}
+
+func TestServe_GracefulHTTP(t *testing.T) {
+	t.Parallel()
+	fx := newTestFixture(t)
+	fx.http.latency = time.Second
+	requestConn := make(chan struct{})
+	fx.http.requestRecvChan = requestConn
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		fx.listen()
+		wg.Done()
+	}()
+
+	// request needs to have a timeout in order to be blocking
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fx.url(), nil)
+	assert.NilError(t, err)
+
+	var callErr error
+	wg.Add(1)
+	go func() {
+		res, err := http.DefaultClient.Do(req)
+		callErr = err
+		if err == nil {
+			_ = res.Body.Close()
+		}
+		wg.Done()
+	}()
+
+	// wait for server to have received request
+	<-requestConn
+
+	// stop listening
+	fx.stop()
+
+	wg.Wait()
+	assert.NilError(t, callErr)
+	assert.NilError(t, fx.lisErr)
+}
+
+func newTestFixture(t *testing.T) *testFixture {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = cloudzap.WithLogger(ctx, zaptest.NewLogger(t))
+	var lc net.ListenConfig
+	lis, err := lc.Listen(ctx, "tcp", ":0")
+	assert.NilError(t, err)
+
+	grpcS := grpc.NewServer()
+	grpcH := &grpcServer{}
+	helloworld.RegisterGreeterServer(grpcS, grpcH)
+	httpH := &httpServer{}
+	httpS := &http.Server{Handler: httpH}
+
+	return &testFixture{
+		ctx:   ctx,
+		stop:  cancel,
+		lis:   lis,
+		grpcS: grpcS,
+		grpc:  grpcH,
+		httpS: httpS,
+		http:  httpH,
+	}
+}
+
+type testFixture struct {
+	ctx    context.Context
+	stop   func()
+	lis    net.Listener
+	grpcS  *grpc.Server
+	grpc   *grpcServer
+	httpS  *http.Server
+	http   *httpServer
+	lisErr error
+}
+
+func (fx *testFixture) url() string {
+	return fmt.Sprintf("http://localhost:%d", fx.lis.Addr().(*net.TCPAddr).Port)
+}
+
+func (fx *testFixture) listen() {
+	if err := ServeGRPCHTTP(fx.ctx, fx.lis, fx.grpcS, fx.httpS); err != nil {
+		fx.lisErr = err
+	}
+}
+
+func greeterClient(t *testing.T, addr net.Addr) helloworld.GreeterClient {
+	t.Helper()
+	conn, err := grpc.Dial(
+		addr.String(),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	assert.NilError(t, err)
+	return helloworld.NewGreeterClient(conn)
+}
+
+var _ helloworld.GreeterServer = &grpcServer{}
+
+type grpcServer struct {
+	latency time.Duration
+	helloworld.UnimplementedGreeterServer
+	requestRecvChan chan<- struct{}
+}
+
+func (g *grpcServer) SayHello(
+	_ context.Context,
+	request *helloworld.HelloRequest,
+) (*helloworld.HelloReply, error) {
+	if g.requestRecvChan != nil {
+		g.requestRecvChan <- struct{}{}
+	}
+	if g.latency != 0 {
+		time.Sleep(g.latency)
+	}
+	return &helloworld.HelloReply{Message: "Hello " + request.GetName()}, nil
+}
+
+type httpServer struct {
+	requestRecvChan chan<- struct{}
+	latency         time.Duration
+}
+
+func (h *httpServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if h.requestRecvChan != nil {
+		h.requestRecvChan <- struct{}{}
+	}
+	if h.latency != 0 {
+		time.Sleep(h.latency)
+	}
+	fmt.Fprintf(w, "Hello")
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.24.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0
 	github.com/google/go-cmp v0.5.6
+	github.com/soheilhy/cmux v0.1.5
 	go.opentelemetry.io/contrib/detectors/gcp v1.3.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.26.1
@@ -20,9 +21,11 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.24.0
 	go.uber.org/zap v1.20.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.66.0
 	google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0
 	google.golang.org/grpc v1.44.0
+	google.golang.org/grpc/examples v0.0.0-20220131204945-980790869b00
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools/v3 v3.1.0
@@ -52,7 +55,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.3.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/net v0.0.0-20211104170005-ce137452f963 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/shirou/gopsutil/v3 v3.21.9 h1:Vn4MUz2uXhqLSiCbGFRc0DILbMVLAY92DSkT8bsYrHg=
 github.com/shirou/gopsutil/v3 v3.21.9/go.mod h1:YWp/H8Qs5fVmf17v7JNZzA0mPJ+mS2e9JdiUF9LlKzQ=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -361,6 +363,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -368,8 +371,8 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211104170005-ce137452f963 h1:8gJUadZl+kWvZBqG/LautX0X6qe5qTC2VI/3V3NBRAY=
-golang.org/x/net v0.0.0-20211104170005-ce137452f963/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -398,6 +401,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -441,6 +445,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -455,6 +460,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -598,6 +604,7 @@ google.golang.org/genproto v0.0.0-20200605102947-12044bf5ea91/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -670,6 +677,8 @@ google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20220131204945-980790869b00 h1:6nmt5QGU2G0wdWDmT9CGkX/QU3BOpHm+c4WmDNomZRg=
+google.golang.org/grpc/examples v0.0.0-20220131204945-980790869b00/go.mod h1:gID3PKrg7pWKntu9Ss6zTLJ0ttC0X9IHgREOCZwbCVU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
In some scenarios you may want to have both `HTTP` and `gRPC` at the same time and due to how Cloud Run works, you may have to use a single port to serve both protocols.

This particular feature has been in use in various production projects in internal Einride projects for quite some time now and should be considered fairly stable.