### PR TITLE
fix(cloudclient): increase default backoff factor to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cloudrunner    CLIENT_RETRY_ENABLED                 bool                        
 cloudrunner    CLIENT_RETRY_INITIALBACKOFF          time.Duration                   200ms                  
 cloudrunner    CLIENT_RETRY_MAXBACKOFF              time.Duration                   60s                    
 cloudrunner    CLIENT_RETRY_MAXATTEMPTS             int                             5                      
-cloudrunner    CLIENT_RETRY_BACKOFFMULTIPLIER       float64                         1.3                    
+cloudrunner    CLIENT_RETRY_BACKOFFMULTIPLIER       float64                         2                      
 cloudrunner    CLIENT_RETRY_RETRYABLESTATUSCODES    []codes.Code                    Unavailable,Unknown    
 cloudrunner    REQUESTLOGGER_MESSAGESIZELIMIT       int                                                    1024
 cloudrunner    REQUESTLOGGER_CODETOLEVEL            map[codes.Code]zapcore.Level                           

--- a/cloudclient/config.go
+++ b/cloudclient/config.go
@@ -38,7 +38,7 @@ type RetryConfig struct {
 	// MaxAttempts is the max number of backoff attempts retried.
 	MaxAttempts int `default:"5"`
 	// BackoffMultiplier is the exponential backoff multiplier.
-	BackoffMultiplier float64 `default:"1.3"`
+	BackoffMultiplier float64 `default:"2"`
 	// RetryableStatusCodes is the set of status codes which may be retried.
 	// Unknown status codes are retried by default for the sake of retrying Google Cloud HTTP load balancer errors.
 	RetryableStatusCodes []codes.Code `default:"Unavailable,Unknown"`


### PR DESCRIPTION
With factor 1.3, the last attempt (5) will wait **at most** 0.75s before
retrying. In practice, this wait time will be much lower, because the
wait time is sampled from a random distribution `random(0,
max_wait_time)`.

The effect is that all retries are attempt very quickly, meaning that
the system on other side of RPC call might not have time to become
available again.

This commit changes the default backoff factor to 2. With this
configuration the last attempt (5) will wait **at most** 6.4s before
retrying. This should give the called RPC ample time to recover.
