### PR TITLE
feat(cloudrequestlog): implement `http.Flusher`

### DIFF
--- a/cloudrequestlog/httpresponsewriter.go
+++ b/cloudrequestlog/httpresponsewriter.go
@@ -25,3 +25,10 @@ func (w *httpResponseWriter) Write(b []byte) (int, error) {
 	w.size += size
 	return size, err
 }
+
+// Flush sends any buffered data to the client.
+func (w *httpResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}


### PR DESCRIPTION
The normal HTTP `ResponseWriter` implements this interface, so let's expose that to users of our wrapper.

Useful for flushing streaming responses.