### PR TITLE
fix: disable exporter by default on GCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cloudrunner    PROFILER_ALLOCFORCEGC                    bool                    
 cloudrunner    TRACEEXPORTER_ENABLED                    bool                                                   true
 cloudrunner    TRACEEXPORTER_TIMEOUT                    time.Duration                   10s                    
 cloudrunner    TRACEEXPORTER_SAMPLEPROBABILITY          float64                         0.01                   
-cloudrunner    METRICEXPORTER_ENABLED                   bool                                                   true
+cloudrunner    METRICEXPORTER_ENABLED                   bool                                                   false
 cloudrunner    METRICEXPORTER_INTERVAL                  time.Duration                   60s                    
 cloudrunner    METRICEXPORTER_RUNTIMEINSTRUMENTATION    bool                                                   true
 cloudrunner    METRICEXPORTER_HOSTINSTRUMENTATION       bool                                                   true

--- a/cloudmonitoring/exporter.go
+++ b/cloudmonitoring/exporter.go
@@ -17,7 +17,7 @@ import (
 
 // ExporterConfig configures the metrics exporter.
 type ExporterConfig struct {
-	Enabled                bool          `onGCE:"true"`
+	Enabled                bool          `onGCE:"false"`
 	Interval               time.Duration `default:"60s"`
 	RuntimeInstrumentation bool          `onGCE:"true"`
 	HostInstrumentation    bool          `onGCE:"true"`


### PR DESCRIPTION
Exporting metric requires GCP `monitoring.googleapis.com` service to be
enabled, or it will continously error.

Changing the default behavior to disable exporting of metrics means it
is safe for users of this library to bump versions without errors.
