### PR TITLE
feat(cloudrequestlog): proxy http.Hijack

### DIFF
--- a/cloudrequestlog/httpresponsewriter.go
+++ b/cloudrequestlog/httpresponsewriter.go
@@ -1,6 +1,11 @@
 package cloudrequestlog
 
-import "net/http"
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
 
 type httpResponseWriter struct {
 	http.ResponseWriter
@@ -31,4 +36,11 @@ func (w *httpResponseWriter) Flush() {
 	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+func (w *httpResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }


### PR DESCRIPTION
I.e. allow users of the cloudrequestlog to also use the hijack func if the underlying ResponseWriter implements it.

Useful for implementing for example websockets.