### PR TITLE
feat: add cloudrunner.ListenGRPCHTTP

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.17
 
-require go.einride.tech/sage v0.110.0
+require go.einride.tech/sage v0.111.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.110.0 h1:Zi2Agix8cy02wVuBPspAmTUHK7XlKJJwztWaeQZ9uYU=
-go.einride.tech/sage v0.110.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.111.0 h1:S0CJ6Dl+QchfQgwpfXO1nu5OkfAKM0i2TpeRuEHr3Es=
+go.einride.tech/sage v0.111.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/cloudmux/mux.go
+++ b/cloudmux/mux.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/soheilhy/cmux"
-	"go.einride.tech/cloudrunner"
+	"go.einride.tech/cloudrunner/cloudzap"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -28,7 +28,10 @@ func ServeGRPCHTTP(
 	m := cmux.New(l)
 	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.Any())
-	logger := cloudrunner.Logger(ctx)
+	logger, ok := cloudzap.GetLogger(ctx)
+	if !ok {
+		logger = zap.NewNop()
+	}
 
 	var g errgroup.Group
 

--- a/muxserver.go
+++ b/muxserver.go
@@ -1,0 +1,23 @@
+package cloudrunner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"go.einride.tech/cloudrunner/cloudmux"
+	"google.golang.org/grpc"
+)
+
+// ListenGRPCHTTP binds a listener on the configured port and listens for gRPC and HTTP requests.
+func ListenGRPCHTTP(ctx context.Context, grpcServer *grpc.Server, httpServer *http.Server) error {
+	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", Runtime(ctx).Port))
+	if err != nil {
+		return fmt.Errorf("serve gRPC and HTTP: %w", err)
+	}
+	if err := cloudmux.ServeGRPCHTTP(ctx, l, grpcServer, httpServer); err != nil {
+		return fmt.Errorf("serve gRPC and HTTP: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Batteries now include gRPC and HTTP muxing.
