### PR TITLE
feat(cloudconfig): add support for secret annotation

### DIFF
--- a/cloudconfig/envconfig.go
+++ b/cloudconfig/envconfig.go
@@ -42,10 +42,11 @@ type Setter interface {
 
 // fieldSpec maintains information about the configuration variable.
 type fieldSpec struct {
-	Name  string
-	Key   string
-	Value reflect.Value
-	Tags  reflect.StructTag
+	Name   string
+	Key    string
+	Secret bool
+	Value  reflect.Value
+	Tags   reflect.StructTag
 }
 
 func collectFieldSpecs(prefix string, spec interface{}) ([]fieldSpec, error) {
@@ -78,10 +79,12 @@ func collectFieldSpecs(prefix string, spec interface{}) ([]fieldSpec, error) {
 			f = f.Elem()
 		}
 		// Capture information about the config variable
+		_, secret := ftype.Tag.Lookup("secret")
 		info := fieldSpec{
-			Name:  ftype.Name,
-			Value: f,
-			Tags:  ftype.Tag,
+			Name:   ftype.Name,
+			Value:  f,
+			Secret: secret,
+			Tags:   ftype.Tag,
 		}
 		// Default to the field name as the env var name (will be upcased)
 		info.Key = info.Name

--- a/cloudconfig/zap.go
+++ b/cloudconfig/zap.go
@@ -22,6 +22,10 @@ type fieldSpecsMarshaler []fieldSpec
 // MarshalLogObject implements zapcore.ObjectMarshaler.
 func (fm fieldSpecsMarshaler) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	for _, fs := range fm {
+		if fs.Secret {
+			encoder.AddString(fs.Key, "<secret>")
+			continue
+		}
 		switch value := fs.Value.Interface().(type) {
 		case time.Duration:
 			encoder.AddDuration(fs.Key, value)

--- a/examples/cmd/additional-config/main.go
+++ b/examples/cmd/additional-config/main.go
@@ -11,7 +11,8 @@ import (
 
 func main() {
 	var config struct {
-		Foo string `default:"bar" onGCE:"baz"`
+		Foo      string `default:"bar" onGCE:"baz"`
+		MySecret string `default:"42" secret:"true"`
 	}
 	if err := cloudrunner.Run(
 		func(ctx context.Context) error {


### PR DESCRIPTION
Annotating config fields as secret prevents them from being logged.
