### PR TITLE
feat(cloudyaml): add ResolveEnvFromFile

### DIFF
--- a/cloudyaml/doc.go
+++ b/cloudyaml/doc.go
@@ -1,0 +1,88 @@
+// Package cloudyaml contains primitives for working with YAML service specifications.
+package cloudyaml
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	"gopkg.in/yaml.v3"
+)
+
+// ResolveEnvFromFile resolves the environment specified in the provided YAML service specification file.
+// Secrets are resolved in the provided Google Cloud project.
+func ResolveEnvFromFile(ctx context.Context, project, filename string) (_ []string, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("resolve env from YAML service specification file %s: %w", filename, err)
+		}
+	}()
+	var config struct {
+		Metadata struct {
+			Name string
+		}
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						Env []struct {
+							Name      string
+							Value     string
+							ValueFrom struct {
+								SecretKeyRef struct {
+									Name string
+									Key  string
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.NewDecoder(bytes.NewReader(data)).Decode(&config); err != nil {
+		return nil, err
+	}
+	if len(config.Spec.Template.Spec.Containers) != 1 {
+		return nil, fmt.Errorf("unexpected number of containers: %d", len(config.Spec.Template.Spec.Containers))
+	}
+	result := make([]string, 0, 100)
+	if config.Metadata.Name != "" {
+		result = append(result, "K_SERVICE="+config.Metadata.Name)
+	}
+	var secretClient *secretmanager.Client
+	for _, env := range config.Spec.Template.Spec.Containers[0].Env {
+		if env.Value != "" {
+			result = append(result, env.Name+"="+env.Value)
+			continue
+		}
+		if env.ValueFrom.SecretKeyRef.Name != "" && env.ValueFrom.SecretKeyRef.Key != "" {
+			if secretClient == nil {
+				secretClient, err = secretmanager.NewClient(ctx)
+				if err != nil {
+					return nil, err
+				}
+			}
+			response, err := secretClient.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+				Name: fmt.Sprintf(
+					"projects/%s/secrets/%s/versions/%s",
+					project,
+					env.ValueFrom.SecretKeyRef.Name,
+					env.ValueFrom.SecretKeyRef.Key,
+				),
+			})
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, env.Name+"="+string(response.GetPayload().GetData()))
+		}
+	}
+	return result, nil
+}

--- a/cloudyaml/doc_test.go
+++ b/cloudyaml/doc_test.go
@@ -1,0 +1,14 @@
+package cloudyaml
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestResolveEnvFromFile(t *testing.T) {
+	actual, err := ResolveEnvFromFile(context.Background(), "-", "testdata/example.yaml")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{"K_SERVICE=example", "FOO=baz", "BAR=3"}, actual)
+}

--- a/cloudyaml/testdata/example.yaml
+++ b/cloudyaml/testdata/example.yaml
@@ -1,0 +1,21 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example
+  annotations:
+    autoscaling.knative.dev/maxScale: "100"
+spec:
+  template:
+    spec:
+      containerConcurrency: 50
+      containers:
+        - image: gcr.io/cloudrun/hello
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          env:
+            - name: FOO
+              value: baz
+            - name: BAR
+              value: 3

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module go.einride.tech/cloudrunner
 go 1.18
 
 require (
-	cloud.google.com/go v0.102.0 // indirect
 	cloud.google.com/go/compute v1.7.0
 	cloud.google.com/go/profiler v0.3.0
-	cloud.google.com/go/trace v1.2.0 // indirect
+	cloud.google.com/go/secretmanager v1.5.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.32.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.3
 	github.com/google/go-cmp v0.5.8
@@ -33,7 +32,10 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.102.0 // indirect
+	cloud.google.com/go/iam v0.3.0 // indirect
 	cloud.google.com/go/monitoring v1.4.0 // indirect
+	cloud.google.com/go/trace v1.2.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.3 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
+cloud.google.com/go/secretmanager v1.5.0 h1:XdbW+Fx5amsRzjHeFbDAQI2v2VUkSl3BWEgkQD6z8hY=
+cloud.google.com/go/secretmanager v1.5.0/go.mod h1:5C9kM+RwSpkURNovKySkNvGQLUaOgyoR5W0RUx2SyHQ=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=


### PR DESCRIPTION
Resolves the config for a Cloud Run service from a YAML service
specification file, including looking up secrets.

Can be used to simplify running services locally that depend on secrets.
