### PR TITLE
feat: add standard traceId log attribute

### DIFF
--- a/cloudtrace/idhook.go
+++ b/cloudtrace/idhook.go
@@ -1,0 +1,19 @@
+package cloudtrace
+
+import (
+	"context"
+
+	"go.einride.tech/cloudrunner/cloudzap"
+	"go.uber.org/zap"
+)
+
+// IDKey is the log entry key for trace IDs.
+// Experimental: May be removed in a future update.
+const IDKey = "traceId"
+
+// IDHook adds the trace ID (without the full trace resource name) to the request logger.
+// The trace ID can be used to filter on logs for the same trace across multiple projects.
+// Experimental: May be removed in a future update.
+func IDHook(ctx context.Context, traceContext Context) context.Context {
+	return cloudzap.WithLoggerFields(ctx, zap.String(IDKey, traceContext.TraceID))
+}

--- a/run.go
+++ b/run.go
@@ -84,6 +84,9 @@ func Run(fn func(context.Context) error, options ...Option) error {
 		return nil
 	}
 	run.traceMiddleware.ProjectID = run.config.Runtime.ProjectID
+	if run.traceMiddleware.TraceHook == nil {
+		run.traceMiddleware.TraceHook = cloudtrace.IDHook
+	}
 	run.serverMiddleware.Config = run.config.Server
 	run.requestLoggerMiddleware.Config = run.config.RequestLogger
 	run.metricMiddleware, err = cloudmonitoring.NewMetricMiddleware()


### PR DESCRIPTION
Makes cross-project trace investigations easier in joined log buckets.
