### PR TITLE
fix(http-request-logger): log the status field in the httpRequest object for 200 status

### DIFF
--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -160,7 +160,7 @@ func (l *Middleware) HTTPServer(next http.Handler) http.Handler {
 		}
 		httpRequest := cloudzap.HTTPRequestObject{
 			RequestMethod: r.Method,
-			Status:        responseWriter.statusCode,
+			Status:        responseWriter.Status(),
 			ResponseSize:  responseWriter.size + measureHeaderSize(w.Header()),
 			UserAgent:     r.UserAgent(),
 			RemoteIP:      r.RemoteAddr,


### PR DESCRIPTION
For http server request logs, the change will make sure a status of 200 is set if no explicit reponse status was set on the httpResponseWriter