### PR TITLE
feat: add method for accessing trace context from http

### DIFF
--- a/cloudtrace/metadata.go
+++ b/cloudtrace/metadata.go
@@ -10,6 +10,8 @@ import (
 const ContextHeader = "x-cloud-trace-context"
 
 // FromIncomingContext returns the incoming Cloud Trace Context.
+// Deprecated: FromIncomingContext does not handle trace context coming from a HTTP server,
+// use GetContext instead.
 func FromIncomingContext(ctx context.Context) (Context, bool) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -21,6 +23,22 @@ func FromIncomingContext(ctx context.Context) (Context, bool) {
 	}
 	var result Context
 	if err := result.UnmarshalString(values[0]); err != nil {
+		return Context{}, false
+	}
+	return result, true
+}
+
+type contextKey struct{}
+
+// SetContext sets the cloud trace context to the provided context.
+func SetContext(ctx context.Context, ctxx Context) context.Context {
+	return context.WithValue(ctx, contextKey{}, ctxx)
+}
+
+// GetContext gets the cloud trace context from the provided context if it exists.
+func GetContext(ctx context.Context) (Context, bool) {
+	result, ok := ctx.Value(contextKey{}).(Context)
+	if !ok {
 		return Context{}, false
 	}
 	return result, true

--- a/cloudtrace/metadata_test.go
+++ b/cloudtrace/metadata_test.go
@@ -1,0 +1,39 @@
+package cloudtrace
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_Context(t *testing.T) {
+	t.Parallel()
+	t.Run("read from empty context", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		value, ok := GetContext(ctx)
+		assert.Equal(t, false, ok)
+		assert.DeepEqual(t, Context{}, value)
+	})
+	t.Run("set and read from context", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		ctx = SetContext(ctx, Context{
+			TraceID: "traceId",
+			SpanID:  "spanId",
+			Sampled: true,
+		})
+		value, ok := GetContext(ctx)
+		assert.Equal(t, true, ok)
+		assert.DeepEqual(
+			t,
+			Context{
+				TraceID: "traceId",
+				SpanID:  "spanId",
+				Sampled: true,
+			},
+			value,
+		)
+	})
+}

--- a/trace.go
+++ b/trace.go
@@ -7,6 +7,12 @@ import (
 )
 
 // IncomingTraceContext returns the Cloud Trace context from the incoming request metadata.
+// Deprecated: Use GetTraceContext instead.
 func IncomingTraceContext(ctx context.Context) (cloudtrace.Context, bool) {
 	return cloudtrace.FromIncomingContext(ctx)
+}
+
+// GetTraceContext returns the Cloud Trace context from the incoming request.
+func GetTraceContext(ctx context.Context) (cloudtrace.Context, bool) {
+	return cloudtrace.GetContext(ctx)
 }


### PR DESCRIPTION
Currently the trace context is read from incoming metadata which is
only populated when the server is called via gRPC. This means there is
no way (see note 1) to read the trace context from a http server (as
incoming metadata is not populated.

---

This commit introduces a separate context.Context value which is populated
by middlewares and accessible for both HTTP and gRPC servers.

The old method is deprecated and replaced with Get/Set Context funcs.

---

Note 1: Technically you can access the trace context in a http server by
reading outgoing metadata, but that is not ideal.
