### PR TITLE
fix(cloudclient): make string matching more resilient

### DIFF
--- a/cloudclient/middleware_test.go
+++ b/cloudclient/middleware_test.go
@@ -51,6 +51,19 @@ func TestHandleHTTPResponseToGRPCRequest(t *testing.T) {
 					"transport: received the unexpected content-type \"text/html; charset=UTF-8\"",
 			),
 		},
+		{
+			name: "HTTP 500 Internal Server Error",
+			err: status.Error(
+				codes.Unknown,
+				"unexpected HTTP status code received from server: 500 (Internal Server Error); "+
+					"transport: received unexpected content-type \"text/html; charset=UTF-8\"",
+			),
+			expected: status.Error(
+				codes.Unavailable,
+				"unexpected HTTP status code received from server: 500 (Internal Server Error); "+
+					"transport: received unexpected content-type \"text/html; charset=UTF-8\"",
+			),
+		},
 
 		{
 			name: "HTTP 403 Forbidden",
@@ -66,16 +79,20 @@ func TestHandleHTTPResponseToGRPCRequest(t *testing.T) {
 					"Forbidden: HTTP status code 403; transport: received the unexpected content-type \"text/html\"",
 			),
 		},
-
 		{
-			name: "missing HTTP status",
+			name: "HTTP 403 Forbidden",
 			err: status.Error(
 				codes.Unknown,
-				"transport: received the unexpected content-type \"text/html\"",
+				"unexpected HTTP status code received from server: 403 (Forbidden); "+
+					"transport: received unexpected content-type \"text/html; charset=UTF-8\"",
 			),
 			expected: status.Error(
-				codes.Unknown,
-				"transport: received the unexpected content-type \"text/html\"",
+				codes.PermissionDenied,
+				"the gRPC request failed with a HTTP 403 error (on Google Cloud this happens when the client "+
+					"service account does not have IAM permissions to call the remote service - on Cloud Run, "+
+					"the client service account must have roles/run.invoker on the remote service): "+
+					"unexpected HTTP status code received from server: 403 (Forbidden); "+
+					"transport: received unexpected content-type \"text/html; charset=UTF-8\"",
 			),
 		},
 	} {


### PR DESCRIPTION
grpc-go recently (July 2022) changed the error messages
for unknown content types, which was matched in this package.

Instead of exactly matching against the messages, and parsting
the status code with a regexp, the middleware makes a simpler search.

The changes in grpc-go can be seen here
https://github.com/grpc/grpc-go/pull/4474/files
