### PR TITLE
feat!: change request logs from OK status to INFO level

### DIFF
--- a/cloudrequestlog/codetolevel.go
+++ b/cloudrequestlog/codetolevel.go
@@ -10,7 +10,7 @@ import (
 func CodeToLevel(code codes.Code) zapcore.Level {
 	switch code {
 	case codes.OK:
-		return zap.DebugLevel
+		return zap.InfoLevel
 	case
 		codes.NotFound,
 		codes.InvalidArgument,

--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -215,7 +215,7 @@ func (l *Middleware) statusToLevel(status int) zapcore.Level {
 	}
 	switch {
 	case status < http.StatusBadRequest:
-		return zap.DebugLevel
+		return zap.InfoLevel
 	case http.StatusBadRequest <= status && status < http.StatusInternalServerError:
 		return zap.WarnLevel
 	case status == http.StatusGatewayTimeout:


### PR DESCRIPTION
It is often not desireable to have debug logs in production however today it is not possible to disable debug logs without also disabling request logs from requests with an OK status.
    
BREAKING CHANGE: Changed OK logs to be written at INFO level