### PR TITLE
fix(cloudclient): dummy change to realse dial.go changes

### DIFF
--- a/cloudclient/dial.go
+++ b/cloudclient/dial.go
@@ -66,7 +66,7 @@ func withDefaultPort(target string, port int) string {
 func newTokenSource(ctx context.Context, target string) (_ oauth2.TokenSource, err error) {
 	defer func() {
 		if err != nil {
-			err = fmt.Errorf("new token source: %w", err)
+			err = fmt.Errorf("new token source error: %w", err)
 		}
 	}()
 	audience := "https://" + trimPort(target)


### PR DESCRIPTION
Perhaps because the last changes on dial.go file was committed with `chore`. So the [0.39.5 version of the code](https://github.com/einride/cloudrunner-go/blob/v0.39.5/cloudclient/dial.go) is different than the current master code.

This minor change on this file should get it released.