### PR TITLE
feat(grpc): add stream middleware interceptors

### DIFF
--- a/cloudserver/middleware.go
+++ b/cloudserver/middleware.go
@@ -6,6 +6,7 @@ import (
 
 	"go.einride.tech/cloudrunner/clouderror"
 	"go.einride.tech/cloudrunner/cloudrequestlog"
+	"go.einride.tech/cloudrunner/cloudstream"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -42,4 +43,31 @@ func (i *Middleware) GRPCUnaryServerInterceptor(
 	ctx, cancel := context.WithTimeout(ctx, i.Config.Timeout)
 	defer cancel()
 	return handler(ctx, req)
+}
+
+// GRPCStreamServerInterceptor implements grpc.StreamServerInterceptor.
+func (i *Middleware) GRPCStreamServerInterceptor(
+	srv interface{},
+	ss grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = clouderror.Wrap(
+				fmt.Errorf("recovered panic: %v", r),
+				status.New(codes.Internal, "internal error"),
+			)
+			if additionalFields, ok := cloudrequestlog.GetAdditionalFields(ss.Context()); ok {
+				additionalFields.Add(zap.Stack("stack"))
+			}
+		}
+	}()
+	if i.Config.Timeout <= 0 {
+		return handler(srv, ss)
+	}
+	ctx, cancel := context.WithTimeout(ss.Context(), i.Config.Timeout)
+	defer cancel()
+
+	return handler(srv, cloudstream.NewContextualServerStream(ctx, ss))
 }

--- a/cloudstream/middleware.go
+++ b/cloudstream/middleware.go
@@ -1,0 +1,27 @@
+package cloudstream
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// ContextualServerStream wraps a "normal" grpc.Server stream but replaces the context.
+// This is useful in for example middlewares.
+type ContextualServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// NewContextualServerStream creates a new server stream, that uses the given context.
+func NewContextualServerStream(ctx context.Context, root grpc.ServerStream) *ContextualServerStream {
+	return &ContextualServerStream{
+		ServerStream: root,
+		ctx:          ctx,
+	}
+}
+
+// Context returns the context for this server stream.
+func (s *ContextualServerStream) Context() context.Context {
+	return s.ctx
+}

--- a/cloudzap/middleware.go
+++ b/cloudzap/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"go.einride.tech/cloudrunner/cloudstream"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -27,4 +28,14 @@ func (l *Middleware) GRPCUnaryServerInterceptor(
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
 	return handler(WithLogger(ctx, l.Logger), request)
+}
+
+// GRPCStreamServerInterceptor adds a zap logger to the server stream context.
+func (l *Middleware) GRPCStreamServerInterceptor(
+	srv interface{},
+	ss grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) (err error) {
+	return handler(srv, cloudstream.NewContextualServerStream(WithLogger(ss.Context(), l.Logger), ss))
 }

--- a/grpcserver.go
+++ b/grpcserver.go
@@ -27,6 +27,14 @@ func NewGRPCServer(ctx context.Context, opts ...grpc.ServerOption) *grpc.Server 
 			run.requestLoggerMiddleware.GRPCUnaryServerInterceptor, // needs to run after trace
 			run.serverMiddleware.GRPCUnaryServerInterceptor,        // needs to run after request logger
 		),
+		grpc.ChainStreamInterceptor(
+			otelgrpc.StreamServerInterceptor(),
+			run.loggerMiddleware.GRPCStreamServerInterceptor,
+			run.traceMiddleware.GRPCStreamServerInterceptor,
+			run.metricMiddleware.GRPCStreamServerInterceptor,
+			run.requestLoggerMiddleware.GRPCStreamServerInterceptor,
+			run.serverMiddleware.GRPCStreamServerInterceptor,
+		),
 		// For details on keepalive settings, see:
 		// https://github.com/grpc/grpc-go/blob/master/Documentation/keepalive.md
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{


### PR DESCRIPTION
The ones used for unary calls are ported over for streaming RPCs. This allows you to use all your familiar contextual tools, such as metrics, tracing, logging etc.