### PR TITLE
feat: add security headers middleware

### DIFF
--- a/cloudserver/security_headers.go
+++ b/cloudserver/security_headers.go
@@ -1,0 +1,18 @@
+package cloudserver
+
+import (
+	"net/http"
+)
+
+// SecurityHeadersMiddleware adds security headers to responses.
+type SecurityHeadersMiddleware struct{}
+
+// HTTPServer provides HTTP server middleware.
+func (i *SecurityHeadersMiddleware) HTTPServer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/httpserver.go
+++ b/httpserver.go
@@ -30,6 +30,7 @@ func NewHTTPServer(ctx context.Context, handler http.Handler, middlewares ...HTT
 		run.loggerMiddleware.HTTPServer,
 		run.traceMiddleware.HTTPServer,
 		run.requestLoggerMiddleware.HTTPServer,
+		run.securityHeadersMiddleware.HTTPServer,
 		run.serverMiddleware.HTTPServer,
 	}
 	return &http.Server{

--- a/run.go
+++ b/run.go
@@ -152,15 +152,16 @@ func Run(fn func(context.Context) error, options ...Option) (err error) {
 }
 
 type runContext struct {
-	config                  runConfig
-	configOptions           []cloudconfig.Option
-	grpcServerOptions       []grpc.ServerOption
-	loggerMiddleware        cloudzap.Middleware
-	serverMiddleware        cloudserver.Middleware
-	clientMiddleware        cloudclient.Middleware
-	requestLoggerMiddleware cloudrequestlog.Middleware
-	traceMiddleware         cloudtrace.Middleware
-	metricMiddleware        cloudmonitoring.MetricMiddleware
+	config                    runConfig
+	configOptions             []cloudconfig.Option
+	grpcServerOptions         []grpc.ServerOption
+	loggerMiddleware          cloudzap.Middleware
+	serverMiddleware          cloudserver.Middleware
+	clientMiddleware          cloudclient.Middleware
+	requestLoggerMiddleware   cloudrequestlog.Middleware
+	traceMiddleware           cloudtrace.Middleware
+	metricMiddleware          cloudmonitoring.MetricMiddleware
+	securityHeadersMiddleware cloudserver.SecurityHeadersMiddleware
 }
 
 type runContextKey struct{}


### PR DESCRIPTION
Add middleware adding security-related headers.
I didn't add this middleware to the server returned from `NewHTTPServer` since it could be a breaking change.