### PR TITLE
fix(cmux): match grpc if grpc+proto content type

### DIFF
--- a/cloudmux/mux.go
+++ b/cloudmux/mux.go
@@ -26,7 +26,10 @@ func ServeGRPCHTTP(
 	httpServer *http.Server,
 ) error {
 	m := cmux.New(l)
-	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	grpcL := m.MatchWithWriters(
+		cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"),
+		cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc+proto"),
+	)
 	httpL := m.Match(cmux.Any())
 	logger, ok := cloudzap.GetLogger(ctx)
 	if !ok {


### PR DESCRIPTION
`buf curl` sends the content-type as application/grpc+proto and you cannot change it. This gets interpreted as HTTP without this fix.