### PR TITLE
ci(dependabot): group opentelemetry updates to a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      opentelemetry:
+        patterns:
+          - "*opentelemetry*"  # Include all dependencies in one PR
 
   - package-ecosystem: gomod
     directory: .sage


### PR DESCRIPTION
These updates generally need to be bumped together, and this should take care of that.