### PR TITLE
feat: add ShutdownDelay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ cloudrunner    CLIENT_RETRY_RETRYABLESTATUSCODES        []codes.Code            
 cloudrunner    REQUESTLOGGER_MESSAGESIZELIMIT           int                                                    1024
 cloudrunner    REQUESTLOGGER_CODETOLEVEL                map[codes.Code]zapcore.Level                           
 cloudrunner    REQUESTLOGGER_STATUSTOLEVEL              map[int]zapcore.Level                                  
+cloudrunner    SHUTDOWNDELAY                            time.Duration                                          
 
 Build-time configuration of grpc-server:
 

--- a/run_test.go
+++ b/run_test.go
@@ -3,15 +3,37 @@ package cloudrunner_test
 import (
 	"context"
 	"log"
+	"syscall"
+	"testing"
+	"time"
 
 	"go.einride.tech/cloudrunner"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"gotest.tools/v3/assert"
 )
 
 func ExampleRun_helloWorld() {
 	if err := cloudrunner.Run(func(ctx context.Context) error {
 		cloudrunner.Logger(ctx).Info("hello world")
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func Test_helloWorldShutdownTimeout(t *testing.T) {
+	t.Setenv("SHUTDOWNDELAY", "1s")
+	if err := cloudrunner.Run(func(ctx context.Context) error {
+		cloudrunner.Logger(ctx).Info("hello world")
+		beforeKill := time.Now()
+		go func() {
+			// Simulating seeding a SIGTERM call.
+			_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		}()
+		<-ctx.Done()
+		afterKill := time.Now()
+		assert.Assert(t, afterKill.Sub(beforeKill).Seconds() > 1.0)
 		return nil
 	}); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This adds an artifical shutdown delay, in order to allow a service to
stop receiving requests before it cancells its root context. This is
completely opt-in, and the added context cancellation delay will not be
added if no duration is configured.
