### PR TITLE
chore(deps): bump the all group with 4 updates

### DIFF
--- a/cloudclient/dial.go
+++ b/cloudclient/dial.go
@@ -40,7 +40,7 @@ func DialService(ctx context.Context, target string, opts ...grpc.DialOption) (*
 			PermitWithoutStream: true,
 		}),
 	}
-	conn, err := grpc.DialContext(ctx, withDefaultPort(target, 443), append(defaultOpts, opts...)...)
+	conn, err := grpc.NewClient(withDefaultPort(target, 443), append(defaultOpts, opts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", target, err)
 	}

--- a/cloudclient/dialinsecure.go
+++ b/cloudclient/dialinsecure.go
@@ -36,7 +36,7 @@ func DialServiceInsecure(ctx context.Context, target string, opts ...grpc.DialOp
 		grpc.WithPerRPCCredentials(insecureTokenSource{TokenSource: idTokenSource}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
-	conn, err := grpc.DialContext(ctx, parsedTarget.Host, append(defaultOpts, opts...)...)
+	conn, err := grpc.NewClient(parsedTarget.Host, append(defaultOpts, opts...)...)
 	if err != nil {
 		return nil, fmt.Errorf("dial insecure '%s': %w", target, err)
 	}

--- a/cloudmux/mux_test.go
+++ b/cloudmux/mux_test.go
@@ -164,7 +164,7 @@ func (fx *testFixture) listen() {
 
 func greeterClient(t *testing.T, addr net.Addr) helloworld.GreeterClient {
 	t.Helper()
-	conn, err := grpc.Dial(
+	conn, err := grpc.NewClient(
 		addr.String(),
 		grpc.WithBlock(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
Bumps the all group with 4 updates: [golang.org/x/net](https://github.com/golang/net), [golang.org/x/oauth2](https://github.com/golang/oauth2), [golang.org/x/sync](https://github.com/golang/sync) and [google.golang.org/grpc](https://github.com/grpc/grpc-go).

Updates `golang.org/x/net` from 0.22.0 to 0.24.0
- [Commits](https://github.com/golang/net/compare/v0.22.0...v0.24.0)

Updates `golang.org/x/oauth2` from 0.18.0 to 0.19.0
- [Commits](https://github.com/golang/oauth2/compare/v0.18.0...v0.19.0)

Updates `golang.org/x/sync` from 0.6.0 to 0.7.0
- [Commits](https://github.com/golang/sync/compare/v0.6.0...v0.7.0)

Updates `google.golang.org/grpc` from 1.62.1 to 1.63.0
- [Release notes](https://github.com/grpc/grpc-go/releases)
- [Commits](https://github.com/grpc/grpc-go/compare/v1.62.1...v1.63.0)
- Change deprecated `Dial` and `DialContext` methods to `NewClient`

---
updated-dependencies:
- dependency-name: golang.org/x/net
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
- dependency-name: golang.org/x/oauth2
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
- dependency-name: golang.org/x/sync
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
- dependency-name: google.golang.org/grpc
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: all
...

Signed-off-by: dependabot[bot] <support@github.com>
