### PR TITLE
feat(cloudconfig): support multi container configuration

### DIFF
--- a/cloudconfig/yaml.go
+++ b/cloudconfig/yaml.go
@@ -49,7 +49,7 @@ func setEnvFromYAMLServiceSpecificationFile(name string) (err error) {
 			return err
 		}
 		containers := config.Spec.Template.Spec.Containers
-		if len(containers) != 1 {
+		if len(containers) == 0 || len(containers) > 10 {
 			return fmt.Errorf("unexpected number of containers: %d", len(containers))
 		}
 		if config.Metadata.Name != "" {
@@ -81,7 +81,7 @@ func setEnvFromYAMLServiceSpecificationFile(name string) (err error) {
 			return err
 		}
 		containers := config.Spec.Template.Spec.Template.Spec.Containers
-		if len(containers) != 1 {
+		if len(containers) == 0 || len(containers) > 10 {
 			return fmt.Errorf("unexpected number of containers: %d", len(containers))
 		}
 		if config.Metadata.Name != "" {


### PR DESCRIPTION
Cloud Run now supports multi container deployments (up to 10 per instance).
With this change, sidecar container defined environment variables are not set for the ingress container.

Official docs: https://cloud.google.com/run/docs/deploying\#multicontainer-yaml
