### PR TITLE
feat: handle i/o timeouts as transient timeout errors

### DIFF
--- a/clouderror/wrap.go
+++ b/clouderror/wrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"syscall"
 
@@ -46,6 +47,8 @@ func WrapTransientCaller(err error, msg string, caller Caller) error {
 	case errors.Is(err, syscall.ECONNRESET):
 		return &wrappedStatusError{status: status.New(codes.Unavailable, msg), err: err, caller: caller}
 	case errors.As(err, &http2.GoAwayError{}):
+		return &wrappedStatusError{status: status.New(codes.Unavailable, msg), err: err, caller: caller}
+	case os.IsTimeout(err):
 		return &wrappedStatusError{status: status.New(codes.Unavailable, msg), err: err, caller: caller}
 	default:
 		return &wrappedStatusError{status: status.New(codes.Internal, msg), err: err, caller: caller}

--- a/clouderror/wrap_test.go
+++ b/clouderror/wrap_test.go
@@ -3,6 +3,7 @@ package clouderror
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"golang.org/x/net/http2"
@@ -78,6 +79,11 @@ func Test_WrapTransient(t *testing.T) {
 				ErrCode:      http2.ErrCodeNo,
 				DebugData:    "deadbeef",
 			},
+			expectedCode: codes.Unavailable,
+		},
+		{
+			name:         "os timeout error",
+			err:          os.ErrDeadlineExceeded,
 			expectedCode: codes.Unavailable,
 		},
 	} {


### PR DESCRIPTION
Ensures i/o timeouts are forwarded as DeadlineExceeded transient errors
to callers, which in turn ensures these errors are retried automatically.
