### PR TITLE
feat(cloudotel): call reader.Shutdown instead of exporter.Shutdown

### DIFF
--- a/cloudotel/metricexporter.go
+++ b/cloudotel/metricexporter.go
@@ -84,9 +84,9 @@ func StartMetricExporter(
 	)
 	otel.SetMeterProvider(provider)
 	shutdown := func() {
-		if err := exporter.Shutdown(context.Background()); err != nil {
+		if err := reader.Shutdown(context.Background()); err != nil {
 			if logger, ok := cloudzap.GetLogger(ctx); ok {
-				const msg = "error stopping metric exporter, final metric export might have failed"
+				const msg = "error stopping periodic reader, final metric export might have failed"
 				switch status.Code(err) {
 				case codes.InvalidArgument:
 					// In case final export happens within the minimum frequency time from the previous export,


### PR DESCRIPTION
The periodic reader collects and exports metrics previously recorded at
a given interval.

In order to make sure we do not miss recorded metrics that have not yet
been exported at shutdown, we need to call the reader's Shutdown method
which performs a last collect and export.

It also performs a shutdown of the exporter so we don't need to do that
ourselves.

relates to [PE-910](https://einride.atlassian.net/browse/PE-910)


[PE-910]: https://einride.atlassian.net/browse/PE-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ