### PR TITLE
feat: override otel "task_id" for cloud run job

### DIFF
--- a/cloudotel/resource.go
+++ b/cloudotel/resource.go
@@ -3,18 +3,29 @@ package cloudotel
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"go.einride.tech/cloudrunner/cloudruntime"
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // NewResource creates and detects attributes for a new OpenTelemetry resource.
 func NewResource(ctx context.Context) (*resource.Resource, error) {
-	result, err := resource.New(
-		ctx,
+	opts := []resource.Option{
 		resource.WithTelemetrySDK(),
 		resource.WithDetectors(gcp.NewDetector()),
-	)
+	}
+
+	// In Cloud Run Job, Opentelemetry uses the underlying metadata instance id as the `task_id` label causing a new
+	// time series every time the job is run which leads to a high cardinality value so we override it.
+	// TODO: Follow-up on https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/874 for possible
+	// changes on this.
+	if e, ok := cloudruntime.TaskIndex(); ok {
+		opts = append(opts, resource.WithAttributes(semconv.FaaSInstanceKey.String(strconv.Itoa(e))))
+	}
+	result, err := resource.New(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("init telemetry resource: %w", err)
 	}


### PR DESCRIPTION
On Cloud Run Job opentelemetry sets the "task_id" to the job instance id
which leads to high cardinality as it changes for every run.

In order to avoid that we override it with the cloud run task index
instead.

relates to [PE-910](https://einride.atlassian.net/browse/PE-910)


[PE-910]: https://einride.atlassian.net/browse/PE-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ