### PR TITLE
feat: downgrade opentelemetry metrics shutdown logs to WARN

### DIFF
--- a/cloudotel/metricexporter.go
+++ b/cloudotel/metricexporter.go
@@ -94,7 +94,7 @@ func StartMetricExporter(
 					// so only warn about it.
 					logger.Warn(msg, zap.Error(err))
 				default:
-					logger.Error(msg, zap.Error(err))
+					logger.Warn(msg, zap.Error(err))
 				}
 			}
 		}


### PR DESCRIPTION
Until we solve issues with context upon shutdown

relates to [PE-910](https://einride.atlassian.net/browse/PE-910)
