### PR TITLE
feat: shutdown otel metrics provider

### DIFF
--- a/cloudotel/metricexporter.go
+++ b/cloudotel/metricexporter.go
@@ -82,9 +82,9 @@ func StartMetricExporter(
 	)
 	otel.SetMeterProvider(provider)
 	shutdown := func() {
-		if err := reader.Shutdown(context.Background()); err != nil {
+		if err := provider.Shutdown(context.Background()); err != nil {
 			if logger, ok := cloudzap.GetLogger(ctx); ok {
-				logger.Warn("error stopping periodic reader, final metric export might have failed", zap.Error(err))
+				logger.Warn("error stopping metric provider, final metric export might have failed", zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
The provider will handle shutting down it's resources, including the
reader.

relates to [PE-910](https://einride.atlassian.net/browse/PE-910)


[PE-910]: https://einride.atlassian.net/browse/PE-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ