### PR TITLE
feat: forklift redact from protobuf-sensitive

### DIFF
--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -22,8 +22,6 @@ import (
 type Middleware struct {
 	// Config for the request logger middleware.
 	Config Config
-	// MessageTransformer is an optional transform applied to proto.Message request and responses.
-	MessageTransformer func(proto.Message) proto.Message
 }
 
 // GRPCUnaryServerInterceptor implements request logging as a grpc.UnaryServerInterceptor.
@@ -244,10 +242,7 @@ func (l *Middleware) messageField(key string, message interface{}) zap.Field {
 }
 
 func (l *Middleware) applyMessageTransform(message proto.Message) proto.Message {
-	if l.MessageTransformer == nil {
-		return message
-	}
-	return l.MessageTransformer(message)
+	return redact(message)
 }
 
 func (l *Middleware) codeToLevel(code codes.Code) zapcore.Level {

--- a/cloudrequestlog/redact.go
+++ b/cloudrequestlog/redact.go
@@ -1,0 +1,47 @@
+package cloudrequestlog
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protopath"
+	"google.golang.org/protobuf/reflect/protorange"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// redact sensitive fields from the input message.
+func redact(input proto.Message) proto.Message {
+	var hasSensitiveFields bool
+	_ = protorange.Range(input.ProtoReflect(), func(values protopath.Values) error {
+		last := values.Index(-1)
+		if _, ok := last.Value.Interface().(string); !ok {
+			return nil
+		}
+		if last.Step.Kind() != protopath.FieldAccessStep {
+			return nil
+		}
+		if !last.Step.FieldDescriptor().Options().(*descriptorpb.FieldOptions).GetDebugRedact() {
+			return nil
+		}
+		hasSensitiveFields = true
+		return protorange.Terminate
+	})
+	if !hasSensitiveFields {
+		return input
+	}
+	output := proto.Clone(input)
+	_ = protorange.Range(output.ProtoReflect(), func(values protopath.Values) error {
+		last := values.Index(-1)
+		if _, ok := last.Value.Interface().(string); !ok {
+			return nil
+		}
+		if last.Step.Kind() != protopath.FieldAccessStep {
+			return nil
+		}
+		if !last.Step.FieldDescriptor().Options().(*descriptorpb.FieldOptions).GetDebugRedact() {
+			return nil
+		}
+		values.Index(-2).Value.Message().Set(last.Step.FieldDescriptor(), protoreflect.ValueOfString("<redacted>"))
+		return nil
+	})
+	return output
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/soheilhy/cmux v0.1.5
-	go.einride.tech/protobuf-sensitive v0.8.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.28.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.einride.tech/protobuf-sensitive v0.8.0 h1:EoeKBbjJFc+K1xvfut6Wat0AY1eMAdmBYmGiBdK8Plw=
-go.einride.tech/protobuf-sensitive v0.8.0/go.mod h1:YkjV9z/m+HxFxtvdEUKdjUhImB5QjTD+mzqAqP5pAnU=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/detectors/gcp v1.28.0 h1:eAaOyCwPqwAG7INWn0JTDD3KFR4qbSlhh0YCuFOmmDE=

--- a/options.go
+++ b/options.go
@@ -6,18 +6,10 @@ import (
 	"go.einride.tech/cloudrunner/cloudconfig"
 	"go.einride.tech/cloudrunner/cloudtrace"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 )
 
 // Option provides optional configuration for a run context.
 type Option func(*runContext)
-
-// WithRequestLoggerMessageTransformer configures the request logger with a message transformer.
-func WithRequestLoggerMessageTransformer(transformer func(proto.Message) proto.Message) Option {
-	return func(run *runContext) {
-		run.requestLoggerMiddleware.MessageTransformer = transformer
-	}
-}
 
 // WithConfig configures an additional config struct to be loaded.
 func WithConfig(name string, config interface{}) Option {

--- a/run.go
+++ b/run.go
@@ -20,7 +20,6 @@ import (
 	"go.einride.tech/cloudrunner/cloudserver"
 	"go.einride.tech/cloudrunner/cloudtrace"
 	"go.einride.tech/cloudrunner/cloudzap"
-	"go.einride.tech/protobuf-sensitive/protosensitive"
 	"go.uber.org/zap"
 	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
@@ -97,9 +96,6 @@ func Run(fn func(context.Context) error, options ...Option) (err error) {
 	}
 	run.serverMiddleware.Config = run.config.Server
 	run.requestLoggerMiddleware.Config = run.config.RequestLogger
-	if run.requestLoggerMiddleware.MessageTransformer == nil {
-		run.requestLoggerMiddleware.MessageTransformer = protosensitive.Redact
-	}
 	ctx = withRunContext(ctx, &run)
 	ctx = cloudruntime.WithConfig(ctx, run.config.Runtime)
 	logger, err := cloudzap.NewLogger(run.config.Logger)


### PR DESCRIPTION
Removes dependency on custom redaction annotation now that we only use
the standard `debug_redact` annotation.
