### PR TITLE
feat(pubsub): extract trace information

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -51,7 +51,10 @@ func GoTest(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	// It is currently not possible to ignore package deprecation lint errors so we ignore
+	// it through flags and match the lint error string.
+	// See https://github.com/golangci/golangci-lint/issues/741#issuecomment-1721737130 for more details.
+	return sggolangcilint.Run(ctx, "--exclude", `SA1019: .go.einride.tech/cloudrunner/cloudtrace. is deprecated:`)
 }
 
 func GoLintFix(ctx context.Context) error {

--- a/cloudotel/traceidhook.go
+++ b/cloudotel/traceidhook.go
@@ -1,0 +1,20 @@
+package cloudotel
+
+import (
+	"context"
+	"log/slog"
+
+	"go.einride.tech/cloudrunner/cloudslog"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// IDKey is the log entry key for trace IDs.
+// Experimental: May be removed in a future update.
+const IDKey = "traceId"
+
+// TraceIDHook adds the trace ID (without the full trace resource name) to the request logger.
+// The trace ID can be used to filter on logs for the same trace across multiple projects.
+// Experimental: May be removed in a future update.
+func TraceIDHook(ctx context.Context, traceContext trace.SpanContext) context.Context {
+	return cloudslog.With(ctx, slog.String(IDKey, traceContext.TraceID().String()))
+}

--- a/cloudotel/tracemiddleware.go
+++ b/cloudotel/tracemiddleware.go
@@ -1,0 +1,99 @@
+package cloudotel
+
+import (
+	"context"
+	"net/http"
+
+	gcppropagator "github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
+	"go.einride.tech/cloudrunner/cloudstream"
+	"go.einride.tech/cloudrunner/cloudzap"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type TraceHook func(context.Context, trace.SpanContext) context.Context
+
+// TraceMiddleware that ensures incoming traces are forwarded and included in logging.
+type TraceMiddleware struct {
+	// ProjectID of the project the service is running in.
+	ProjectID string
+	// TraceHook is an optional callback that gets called with the parsed trace context.
+	TraceHook TraceHook
+	// propagator is a opentelemetry trace propagator
+	propagator propagation.TextMapPropagator
+}
+
+func NewTraceMiddleware() TraceMiddleware {
+	propagator := propagation.NewCompositeTextMapPropagator(
+		gcppropagator.CloudTraceFormatPropagator{},
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	)
+	return TraceMiddleware{
+		TraceHook:  TraceIDHook,
+		propagator: propagator,
+	}
+}
+
+// GRPCServerUnaryInterceptor provides unary RPC middleware for gRPC servers.
+func (i *TraceMiddleware) GRPCServerUnaryInterceptor(
+	ctx context.Context,
+	req interface{},
+	_ *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (resp interface{}, err error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return handler(ctx, req)
+	}
+	carrier := propagation.HeaderCarrier(md)
+	ctx = i.propagator.Extract(ctx, carrier)
+	ctx = i.withLogTracing(ctx, trace.SpanContextFromContext(ctx))
+	return handler(ctx, req)
+}
+
+// GRPCStreamServerInterceptor adds tracing metadata to streaming RPCs.
+func (i *TraceMiddleware) GRPCStreamServerInterceptor(
+	srv interface{},
+	ss grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) (err error) {
+	md, ok := metadata.FromIncomingContext(ss.Context())
+	if !ok {
+		return handler(srv, ss)
+	}
+	ctx := ss.Context()
+	carrier := propagation.HeaderCarrier(md)
+	ctx = i.propagator.Extract(ctx, carrier)
+	ctx = i.withLogTracing(ctx, trace.SpanContextFromContext(ctx))
+	return handler(srv, cloudstream.NewContextualServerStream(ctx, ss))
+}
+
+// HTTPServer provides middleware for HTTP servers.
+func (i *TraceMiddleware) HTTPServer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		carrier := propagation.HeaderCarrier(r.Header)
+		ctx := i.propagator.Extract(r.Context(), carrier)
+		ctx = i.withLogTracing(ctx, trace.SpanContextFromContext(ctx))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (i *TraceMiddleware) withLogTracing(ctx context.Context, spanCtx trace.SpanContext) context.Context {
+	if i.TraceHook != nil {
+		ctx = i.TraceHook(ctx, spanCtx)
+	}
+	fields := make([]zap.Field, 0, 3)
+	fields = append(fields, cloudzap.Trace(i.ProjectID, spanCtx.TraceID().String()))
+	if spanCtx.SpanID().String() != "" {
+		fields = append(fields, cloudzap.SpanID(spanCtx.SpanID().String()))
+	}
+	if spanCtx.IsSampled() {
+		fields = append(fields, cloudzap.TraceSampled(spanCtx.IsSampled()))
+	}
+	return cloudzap.WithLoggerFields(ctx, fields...)
+}

--- a/cloudtesting/trace.go
+++ b/cloudtesting/trace.go
@@ -3,11 +3,12 @@ package cloudtesting
 import (
 	"context"
 
-	"go.einride.tech/cloudrunner/cloudtrace"
+	cloudtrace "go.einride.tech/cloudrunner/cloudtrace"
 	"google.golang.org/grpc/metadata"
 )
 
 // WithIncomingTraceContext returns a new context with the specified trace.
+// Deprecated: use opentelemetry trace.ContextWithSpanContext instead.
 func WithIncomingTraceContext(ctx context.Context, traceContext cloudtrace.Context) context.Context {
 	md, _ := metadata.FromIncomingContext(ctx)
 	return metadata.NewIncomingContext(

--- a/cloudtrace/doc.go
+++ b/cloudtrace/doc.go
@@ -1,2 +1,6 @@
 // Package cloudtrace provides primitives for Cloud Trace integration.
+//
+// Deprecated: Google Cloud now officially supports the W3C standard for trace-context in their various products
+// and recommends using that instead. On top of that OpenTelemetry now also has official support for tracing so we
+// recommend using opentelemetry package for working with traces.
 package cloudtrace

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	cloud.google.com/go v0.118.1 // indirect
 	cloud.google.com/go/auth v0.15.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
+	cloud.google.com/go/iam v1.3.1 // indirect
 	cloud.google.com/go/longrunning v0.6.4 // indirect
 	cloud.google.com/go/monitoring v1.23.0 // indirect
 	cloud.google.com/go/trace v1.11.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
 cloud.google.com/go/iam v1.3.1 h1:KFf8SaT71yYq+sQtRISn90Gyhyf4X8RGgeAVC8XGf3E=
 cloud.google.com/go/iam v1.3.1/go.mod h1:3wMtuyT4NcbnYNPLMBzYRFiEfjKfJlLVLrisE7bwm34=
+cloud.google.com/go/kms v1.20.5 h1:aQQ8esAIVZ1atdJRxihhdxGQ64/zEbJoJnCz/ydSmKg=
+cloud.google.com/go/kms v1.20.5/go.mod h1:C5A8M1sv2YWYy1AE6iSrnddSG9lRGdJq5XEdBy28Lmw=
 cloud.google.com/go/logging v1.13.0 h1:7j0HgAp0B94o1YRDqiqm26w4q1rDMH7XNRU34lJXHYc=
 cloud.google.com/go/logging v1.13.0/go.mod h1:36CoKh6KA/M0PbhPKMq6/qety2DCAErbhXT62TuXALA=
 cloud.google.com/go/longrunning v0.6.4 h1:3tyw9rO3E2XVXzSApn1gyEEnH2K9SynNQjMlBi3uHLg=
@@ -163,6 +165,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.einride.tech/aip v0.68.1 h1:16/AfSxcQISGN5z9C5lM+0mLYXihrHbQ1onvYTr93aQ=
+go.einride.tech/aip v0.68.1/go.mod h1:XaFtaj4HuA3Zwk9xoBtTWgNubZ0ZZXv9BZJCkuKuWbg=
 go.einride.tech/protobuf-sensitive v0.8.0 h1:EoeKBbjJFc+K1xvfut6Wat0AY1eMAdmBYmGiBdK8Plw=
 go.einride.tech/protobuf-sensitive v0.8.0/go.mod h1:YkjV9z/m+HxFxtvdEUKdjUhImB5QjTD+mzqAqP5pAnU=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/httpserver.go
+++ b/httpserver.go
@@ -24,12 +24,16 @@ func NewHTTPServer(ctx context.Context, handler http.Handler, middlewares ...HTT
 	if !ok {
 		panic("cloudrunner.NewHTTPServer: must be called with a context from cloudrunner.Run")
 	}
+	tracingMiddleware := run.otelTraceMiddleware.HTTPServer
+	if run.useLegacyTracing {
+		tracingMiddleware = run.traceMiddleware.HTTPServer
+	}
 	defaultMiddlewares := []cloudserver.HTTPMiddleware{
 		func(handler http.Handler) http.Handler {
 			return otelhttp.NewHandler(handler, "server")
 		},
 		run.loggerMiddleware.HTTPServer,
-		run.traceMiddleware.HTTPServer,
+		tracingMiddleware,
 		run.requestLoggerMiddleware.HTTPServer,
 		run.securityHeadersMiddleware.HTTPServer,
 		run.serverMiddleware.HTTPServer,

--- a/options.go
+++ b/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.einride.tech/cloudrunner/cloudconfig"
+	"go.einride.tech/cloudrunner/cloudotel"
 	"go.einride.tech/cloudrunner/cloudtrace"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -42,8 +43,17 @@ func WithGRPCServerOptions(grpcServerOptions ...grpc.ServerOption) Option {
 }
 
 // WithTraceHook configures the run context with a trace hook.
+// Deprecated: use WithOtelTraceHook instead.
 func WithTraceHook(traceHook func(context.Context, cloudtrace.Context) context.Context) Option {
 	return func(run *runContext) {
+		run.useLegacyTracing = true
 		run.traceMiddleware.TraceHook = traceHook
+	}
+}
+
+// WithTraceHook configures the run context with a trace hook.
+func WithOtelTraceHook(traceHook cloudotel.TraceHook) Option {
+	return func(run *runContext) {
+		run.otelTraceMiddleware.TraceHook = traceHook
 	}
 }

--- a/trace.go
+++ b/trace.go
@@ -3,16 +3,17 @@ package cloudrunner
 import (
 	"context"
 
-	"go.einride.tech/cloudrunner/cloudtrace"
+	cloudtrace "go.einride.tech/cloudrunner/cloudtrace"
 )
 
 // IncomingTraceContext returns the Cloud Trace context from the incoming request metadata.
-// Deprecated: Use GetTraceContext instead.
+// Deprecated: Use opentelemetry trace.SpanContextFromContext instead.
 func IncomingTraceContext(ctx context.Context) (cloudtrace.Context, bool) {
 	return cloudtrace.FromIncomingContext(ctx)
 }
 
 // GetTraceContext returns the Cloud Trace context from the incoming request.
+// Deprecated: Use opentelemetry trace.SpanContextFromContext instead.
 func GetTraceContext(ctx context.Context) (cloudtrace.Context, bool) {
 	return cloudtrace.GetContext(ctx)
 }


### PR DESCRIPTION
Pass a context that contains trace information extracted from the incoming message, allowing traces to span from publishers over to subscribers.

In order for publishers to include tracing information, the pubsub client should be created with:
```go
client, err := pubsub.NewClientWithConfig(
        ctx,
        cloudrunner.Runtime(ctx).ProjectID,
        &pubsub.ClientConfig{
                EnableOpenTelemetryTracing: true,
        },
```

Depends on https://github.com/googleapis/google-cloud-go/pull/10827 which is included in [v1.43.0](https://github.com/googleapis/google-cloud-go/releases/tag/pubsub%2Fv1.43.0).