### PR TITLE
feat(clouderror)!: preserve grpc error code if present

### DIFF
--- a/clouderror/wrap.go
+++ b/clouderror/wrap.go
@@ -33,11 +33,11 @@ func WrapTransient(err error, msg string) error {
 // WrapTransientCaller wraps transient errors with an appropriate codes.Code and caller.
 // The returned error will always be a status.Status with description set to msg.
 func WrapTransientCaller(err error, msg string, caller Caller) error {
+	if err == nil {
+		return &wrappedStatusError{status: status.New(codes.Internal, msg), err: nil, caller: caller}
+	}
 	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Unauthenticated, codes.PermissionDenied:
-			return &wrappedStatusError{status: status.New(s.Code(), msg), err: err, caller: caller}
-		}
+		return &wrappedStatusError{status: s, err: err, caller: caller}
 	}
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):


### PR DESCRIPTION
This feature ensures that the original gRPC error code is preserved
when an error is wrapped, rather than being automatically promoted to a
generic `Internal` error.

### Problem

When a downstream function throws a gRPC error, and the callee wraps that error
(as shown in the code snippet), the original error code (e.g., `InvalidArgument`)
is replaced with a `Internal` error.

```go
func Handle() (any, error){
	resp, err := Service()
	if err != nil {
		return nil, cloudrunner.WrapTransient(err, "service error")
	}
	return resp, nil
}

func Service() (any, error){
	return nil, status.Error(codes.InvalidArgument, codes.InvalidArgument.String())
}
```

This is a breaking change in the sense that it changes the behavior of `WrapTransient`.

TRA-1791
