### PR TITLE
revert: "feat: preserve auth errors in cloudrunner.WrapTransient"

### DIFF
--- a/clouderror/wrap.go
+++ b/clouderror/wrap.go
@@ -35,7 +35,7 @@ func WrapTransient(err error, msg string) error {
 func WrapTransientCaller(err error, msg string, caller Caller) error {
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() {
-		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Unauthenticated, codes.PermissionDenied:
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
 			return &wrappedStatusError{status: status.New(s.Code(), msg), err: err, caller: caller}
 		}
 	}

--- a/clouderror/wrap_test.go
+++ b/clouderror/wrap_test.go
@@ -40,16 +40,6 @@ func Test_WrapTransient(t *testing.T) {
 			expectedCode: codes.Unavailable,
 		},
 		{
-			name:         "codes.Unauthenticated",
-			err:          status.Error(codes.Unauthenticated, "transient"),
-			expectedCode: codes.Unauthenticated,
-		},
-		{
-			name:         "codes.PermissionDenied",
-			err:          status.Error(codes.PermissionDenied, "transient"),
-			expectedCode: codes.PermissionDenied,
-		},
-		{
 			name: "wrapped transient",
 			err: Wrap(
 				fmt.Errorf("network unavailable"),


### PR DESCRIPTION
This reverts commit d62a6a3d8fea45a88ff391fecdd207dfc3dc47d2.

This commit breaks the API description of only forwarding transient
(retryable) errors.
