### PR TITLE
feat(cloudslog): add context-based attributes

### DIFF
--- a/cloudslog/context.go
+++ b/cloudslog/context.go
@@ -1,0 +1,52 @@
+package cloudslog
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+type contextKey struct{}
+
+// With appends log attributes to the current parent context.
+// Arguments are converted to attributes as if by [slog.Logger.Log].
+func With(parent context.Context, args ...any) context.Context {
+	if v, ok := parent.Value(contextKey{}).([]slog.Attr); ok {
+		return context.WithValue(parent, contextKey{}, append(slices.Clip(v), argsToAttrSlice(args)...))
+	}
+	return context.WithValue(parent, contextKey{}, argsToAttrSlice(args))
+}
+
+func attributesFromContext(ctx context.Context) []slog.Attr {
+	if v, ok := ctx.Value(contextKey{}).([]slog.Attr); ok {
+		return v
+	}
+	return nil
+}
+
+// argsToAttrSlice is copied from the slog stdlib.
+func argsToAttrSlice(args []any) []slog.Attr {
+	var attr slog.Attr
+	attrs := make([]slog.Attr, 0, len(args))
+	for len(args) > 0 {
+		attr, args = argsToAttr(args)
+		attrs = append(attrs, attr)
+	}
+	return attrs
+}
+
+// argsToAttr is copied from the slog stdlib.
+func argsToAttr(args []any) (slog.Attr, []any) {
+	const badKey = "!BADKEY"
+	switch x := args[0].(type) {
+	case string:
+		if len(args) == 1 {
+			return slog.String(badKey, x), nil
+		}
+		return slog.Any(x, args[1]), args[2:]
+	case slog.Attr:
+		return x, args[1:]
+	default:
+		return slog.Any(badKey, x), args[1:]
+	}
+}

--- a/cloudslog/context_test.go
+++ b/cloudslog/context_test.go
@@ -1,0 +1,51 @@
+package cloudslog
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHandler_withContextAttributes(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		ctx := context.Background()
+		ctx = With(ctx, "foo", "bar")
+		logger.InfoContext(ctx, "test")
+		assert.Assert(t, strings.Contains(b.String(), `"foo":"bar"`))
+	})
+
+	t.Run("attrs", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		ctx := context.Background()
+		ctx = With(ctx, slog.String("foo", "bar"), slog.Int("baz", 3))
+		logger.InfoContext(ctx, "test")
+		assert.Assert(t, strings.Contains(b.String(), `"foo":"bar","baz":3`))
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		ctx := context.Background()
+		ctx = With(ctx, "foo", "bar")
+		ctx = With(ctx, "lorem", "ipsum")
+		logger.InfoContext(ctx, "test")
+		assert.Assert(t, strings.Contains(b.String(), `"foo":"bar","lorem":"ipsum"`))
+	})
+
+	t.Run("scoped", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		ctx := context.Background()
+		ctx = With(ctx, "foo", "bar")
+		_ = With(ctx, "lorem", "ipsum")
+		logger.InfoContext(ctx, "test")
+		assert.Assert(t, strings.Contains(b.String(), `"foo":"bar"`))
+		assert.Assert(t, !strings.Contains(b.String(), `"lorem":"ipsum"`))
+	})
+}

--- a/cloudslog/handler.go
+++ b/cloudslog/handler.go
@@ -63,6 +63,7 @@ func (t *handler) Handle(ctx context.Context, record slog.Record) error {
 		record.AddAttrs(slog.Any("logging.googleapis.com/spanId", s.SpanID()))
 		record.AddAttrs(slog.Bool("logging.googleapis.com/trace_sampled", s.TraceFlags().IsSampled()))
 	}
+	record.AddAttrs(attributesFromContext(ctx)...)
 	return t.Handler.Handle(ctx, record)
 }
 


### PR DESCRIPTION
For feature-parity with Zap logger.
