### PR TITLE
fix(cloudslog): don't over-redact fields

### DIFF
--- a/cloudslog/redact.go
+++ b/cloudslog/redact.go
@@ -40,7 +40,6 @@ func redact(input proto.Message) {
 			values.Index(-2).Value.Message().Set(last.Step.FieldDescriptor(), protoreflect.ValueOfString("<redacted>"))
 			return nil
 		}
-		values.Index(-2).Value.Message().Set(last.Step.FieldDescriptor(), protoreflect.ValueOfString("<redacted>"))
 		return nil
 	})
 }

--- a/cloudslog/redact_test.go
+++ b/cloudslog/redact_test.go
@@ -10,10 +10,23 @@ import (
 )
 
 func TestHandler_redact(t *testing.T) {
-	var b strings.Builder
-	logger := slog.New(newHandler(&b, LoggerConfig{}))
-	logger.Info("test", "example", &examplev1.ExampleMessage{
-		DebugRedactedField: "foobar",
+	t.Run("redacted field", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		logger.Info("test", "example", &examplev1.ExampleMessage{
+			DebugRedactedField: "foobar",
+		})
+		assert.Assert(t, strings.Contains(b.String(), `"debugRedactedField":"<redacted>"`), b.String())
 	})
-	assert.Assert(t, strings.Contains(b.String(), `"debugRedactedField":"<redacted>"`), b.String())
+
+	t.Run("redacted and non-redacted field", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{}))
+		logger.Info("test", "example", &examplev1.ExampleMessage{
+			DebugRedactedField: "foobar",
+			NonSensitiveField:  "baz",
+		})
+		assert.Assert(t, strings.Contains(b.String(), `"debugRedactedField":"<redacted>"`), b.String())
+		assert.Assert(t, strings.Contains(b.String(), `"nonSensitiveField":"baz"`), b.String())
+	})
 }


### PR DESCRIPTION
Due to a bug, messages with redacted fields were having all string
fields redacted.
