### PR TITLE
fix(cloudrequestlog): use slog attrs instead of zap fields

### DIFF
--- a/cloudrequestlog/config.go
+++ b/cloudrequestlog/config.go
@@ -9,7 +9,7 @@ import (
 // Config contains request logging config.
 type Config struct {
 	// MessageSizeLimit is the maximum size, in bytes, of requests and responses to log.
-	// Messages large than the limit will be truncated.
+	// Messages larger than the limit will be truncated.
 	// Default value, 0, means that no messages will be truncated.
 	MessageSizeLimit int `onGCE:"1024"`
 	// CodeToLevel enables overriding the default gRPC code to level conversion.

--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -213,7 +213,7 @@ func (l *Middleware) HTTPServer(next http.Handler) http.Handler {
 			httpRequest.RequestUrl = r.URL.String()
 		}
 		attrs := []slog.Attr{
-			slog.Any("httpRequest", &httpRequest),
+			slog.Any("httpRequest", httpRequest),
 		}
 		if additionalFields, ok := GetAdditionalFields(ctx); ok {
 			attrs = additionalFields.AppendTo(attrs)


### PR DESCRIPTION
The cloudrequestlog middleware uses a slog logger to log, but users adding slog attrs, get converted to zap fields, and then back to slog attrs when logged.

This changes so we store slog attrs, and convert zap fields to slog attrs instead of the other way around.

This worked well in most cases when you used primitive types, but if you used grouped values and such it didn't log that properly.

Note you can still provide zap fields to the cloudrequestlog for compatibility reasons.