### PR TITLE
fix(trace): propagate trace from pubsub msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ cloudrunner    CLOUD_RUN_TASK_COUNT                     int
 cloudrunner    GOOGLE_CLOUD_PROJECT                     string                                              
 cloudrunner    RUNTIME_SERVICEACCOUNT                   string                                              
 cloudrunner    SERVICE_VERSION                          string                                              
+cloudrunner    ENABLE_PUBSUB_TRACING                    bool                                                
 cloudrunner    LOGGER_DEVELOPMENT                       bool                         true                   false
 cloudrunner    LOGGER_LEVEL                             zapcore.Level                debug                  info
 cloudrunner    LOGGER_REPORTERRORS                      bool                                                true

--- a/cloudotel/tracemiddleware.go
+++ b/cloudotel/tracemiddleware.go
@@ -1,10 +1,17 @@
 package cloudotel
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	gcppropagator "github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
+	"go.einride.tech/cloudrunner/cloudpubsub"
 	"go.einride.tech/cloudrunner/cloudstream"
 	"go.einride.tech/cloudrunner/cloudzap"
 	"go.opentelemetry.io/otel/propagation"
@@ -78,6 +85,8 @@ func (i *TraceMiddleware) HTTPServer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		carrier := propagation.HeaderCarrier(r.Header)
 		ctx := i.propagator.Extract(r.Context(), carrier)
+		// Check if it is a Pub/Sub message and propagate tracing if exists.
+		ctx = propagatePubsubTracing(ctx, r)
 		ctx = i.withLogTracing(ctx, trace.SpanContextFromContext(ctx))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -96,4 +105,42 @@ func (i *TraceMiddleware) withLogTracing(ctx context.Context, spanCtx trace.Span
 		fields = append(fields, cloudzap.TraceSampled(spanCtx.IsSampled()))
 	}
 	return cloudzap.WithLoggerFields(ctx, fields...)
+}
+
+func propagatePubsubTracing(ctx context.Context, r *http.Request) context.Context {
+	if r.Method != http.MethodPost {
+		return ctx
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return ctx
+	}
+	// Replace the original request body, so it can be read again.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	pubsubPayload, err := tryUnmarshalAsPubsubPayload(body)
+	if err != nil {
+		return ctx
+	}
+	pubsubMessage := pubsubPayload.BuildPubSubMessage()
+	ctx = injectTracingFromPubsubMsg(ctx, &pubsubMessage)
+	return ctx
+}
+
+func tryUnmarshalAsPubsubPayload(body []byte) (cloudpubsub.Payload, error) {
+	var payload cloudpubsub.Payload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return payload, err
+	}
+	if !payload.IsValid() {
+		return payload, errors.New("not a pubsub payload")
+	}
+	return payload, nil
+}
+
+func injectTracingFromPubsubMsg(ctx context.Context, pubsubMessage *pubsubpb.PubsubMessage) context.Context {
+	tc := propagation.TraceContext{}
+	ctx = tc.Extract(ctx, pubsub.NewMessageCarrierFromPB(pubsubMessage))
+	carrier := make(propagation.MapCarrier)
+	tc.Inject(ctx, &carrier)
+	return ctx
 }

--- a/cloudotel/tracemiddleware_test.go
+++ b/cloudotel/tracemiddleware_test.go
@@ -1,0 +1,105 @@
+package cloudotel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/propagation"
+	"gotest.tools/v3/assert"
+)
+
+func TestPropagatePubSubTracing(t *testing.T) {
+	t.Run("valid pubsub payload", func(t *testing.T) {
+		// arrange
+		ctx := context.Background()
+		payload := `{
+			"subscription": "projects/test-project/subscriptions/test-sub",
+			"message": {
+				"attributes": {
+					"googclient_traceparent": "00-161d8104e1e09a3e3a4d80129acbfe30-75a8fe4fee0c65b8-00"
+				},
+				"data": "data",
+				"messageId": "12345",
+				"publishTime": "2025-03-24T12:34:56Z"
+			},
+			"deliveryAttempt": "5"
+		}`
+		req := &http.Request{
+			Method: http.MethodPost,
+			Body:   newReadCloser(payload),
+		}
+
+		// act
+		ctx = propagatePubsubTracing(ctx, req)
+
+		// assert
+		actualTraceContext := extractTraceContext(ctx)
+		expectedTraceContext := `{"traceparent":"00-161d8104e1e09a3e3a4d80129acbfe30-75a8fe4fee0c65b8-00"}`
+		assert.Equal(t, expectedTraceContext, actualTraceContext)
+
+		actualPayload, err := io.ReadAll(req.Body)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, string(actualPayload), payload)
+	})
+
+	t.Run("non pubsub payload", func(t *testing.T) {
+		// arrange
+		ctx := context.Background()
+		payload := `{"user": "test-user", "action": "login"}`
+		req := &http.Request{
+			Method: http.MethodPost,
+			Body:   newReadCloser(payload),
+		}
+
+		// act
+		ctx = propagatePubsubTracing(ctx, req)
+
+		// assert
+		actualTraceContext := extractTraceContext(ctx)
+		assert.Equal(t, "{}", actualTraceContext)
+
+		actualPayload, err := io.ReadAll(req.Body)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, string(actualPayload), payload)
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		// arrange
+		ctx := context.Background()
+		payload := `"message":{"messageId":12345,data":"data","attributes":{"key""value"}}`
+		req := &http.Request{
+			Method: http.MethodPost,
+			Body:   newReadCloser(payload),
+		}
+
+		// act
+		ctx = propagatePubsubTracing(ctx, req)
+
+		// assert
+		actualTraceContext := extractTraceContext(ctx)
+		assert.Equal(t, "{}", actualTraceContext)
+
+		actualPayload, err := io.ReadAll(req.Body)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, string(actualPayload), payload)
+	})
+}
+
+func extractTraceContext(ctx context.Context) string {
+	propagator := propagation.TraceContext{}
+	carrier := make(propagation.MapCarrier)
+	propagator.Inject(ctx, carrier)
+	data, err := json.Marshal(carrier)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func newReadCloser(content string) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader([]byte(content)))
+}

--- a/cloudpubsub/payload.go
+++ b/cloudpubsub/payload.go
@@ -1,0 +1,35 @@
+package cloudpubsub
+
+import (
+	"time"
+
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type PubSubMessage struct {
+	Attributes  map[string]string `json:"attributes"`
+	Data        []byte            `json:"data"`
+	MessageID   string            `json:"messageId"`
+	PublishTime time.Time         `json:"publishTime"`
+	OrderingKey string            `json:"orderingKey"`
+}
+
+type Payload struct {
+	Subscription string        `json:"subscription"`
+	Message      PubSubMessage `json:"message"`
+}
+
+func (p Payload) IsValid() bool {
+	return p.Message.MessageID != ""
+}
+
+func (p Payload) BuildPubSubMessage() pubsubpb.PubsubMessage {
+	return pubsubpb.PubsubMessage{
+		Data:        p.Message.Data,
+		Attributes:  p.Message.Attributes,
+		MessageId:   p.Message.MessageID,
+		PublishTime: timestamppb.New(p.Message.PublishTime),
+		OrderingKey: p.Message.OrderingKey,
+	}
+}

--- a/cloudruntime/config.go
+++ b/cloudruntime/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	ServiceAccount string
 	// ServiceVersion is the version of the service.
 	ServiceVersion string `env:"SERVICE_VERSION"`
+	// EnablePubsubTracing, disabled by default, reads trace parent from Pub/Sub message attributes.
+	EnablePubsubTracing bool `env:"ENABLE_PUBSUB_TRACING"`
 }
 
 // Resolve the runtime config.
@@ -79,6 +81,9 @@ func (c *Config) Resolve(ctx context.Context) error {
 	}
 	if taskCount, ok := TaskCount(); ok {
 		c.TaskCount = taskCount
+	}
+	if enablePubsubTracing, ok := EnablePubsubTracing(); ok {
+		c.EnablePubsubTracing = enablePubsubTracing
 	}
 	return nil
 }

--- a/cloudruntime/env.go
+++ b/cloudruntime/env.go
@@ -62,3 +62,9 @@ func TaskCount() (int, bool) {
 	taskIndex, err := strconv.Atoi(os.Getenv("CLOUD_RUN_TASK_COUNT"))
 	return taskIndex, err == nil
 }
+
+// EnablePubsubTracing returns a boolean indicating whether Pub/Sub tracing is enabled (false by default).
+func EnablePubsubTracing() (bool, bool) {
+	enablePubsubTracing, err := strconv.ParseBool(os.Getenv("ENABLE_PUBSUB_TRACING"))
+	return enablePubsubTracing, err == nil
+}

--- a/cloudruntime/env_test.go
+++ b/cloudruntime/env_test.go
@@ -180,6 +180,39 @@ func TestTaskCount(t *testing.T) {
 	})
 }
 
+func TestEnablePubsubTracing(t *testing.T) {
+	t.Run("disabled from env", func(t *testing.T) {
+		const expected = false
+		setEnv(t, "ENABLE_PUBSUB_TRACING", "false")
+		actual, ok := EnablePubsubTracing()
+		assert.Assert(t, ok)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("enabled from env", func(t *testing.T) {
+		const expected = true
+		setEnv(t, "ENABLE_PUBSUB_TRACING", "true")
+		actual, ok := EnablePubsubTracing()
+		assert.Assert(t, ok)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("undefined", func(t *testing.T) {
+		const expected = false
+		actual, ok := EnablePubsubTracing()
+		assert.Assert(t, !ok)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		const expected = false
+		setEnv(t, "ENABLE_PUBSUB_TRACING", "invalid")
+		actual, ok := EnablePubsubTracing()
+		assert.Assert(t, !ok)
+		assert.Equal(t, expected, actual)
+	})
+}
+
 // setEnv will be available in the standard library from Go 1.17 as t.SetEnv.
 func setEnv(t *testing.T, key, value string) {
 	prevValue, ok := os.LookupEnv(key)

--- a/run.go
+++ b/run.go
@@ -94,6 +94,7 @@ func Run(fn func(context.Context) error, options ...Option) (err error) {
 		run.traceMiddleware.TraceHook = cloudtrace.IDHook
 	}
 	run.otelTraceMiddleware.ProjectID = run.config.Runtime.ProjectID
+	run.otelTraceMiddleware.EnablePubsubTracing = run.config.Runtime.EnablePubsubTracing
 	run.serverMiddleware.Config = run.config.Server
 	run.requestLoggerMiddleware.Config = run.config.RequestLogger
 	ctx = withRunContext(ctx, &run)


### PR DESCRIPTION
this ensures that tracing from the pubsub message is properly propagated before we create a context with log tracing. Without this fix, the cloudrequestlog middleware logs incorrectly and incorrect traceId is attached to the slog field with TraceHook.

There’s no reliable way to determine whether the request originates from pubsub without attempting to decode it. I could make this configurable to avoid propagating the trace when it's not wanted.

Let’s discuss if you have any better ideas for addressing this!