### PR TITLE
feat(cloudruntime): resolve delegated service account

### DIFF
--- a/cloudruntime/metadata.go
+++ b/cloudruntime/metadata.go
@@ -3,7 +3,10 @@ package cloudruntime
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2/google"
@@ -66,14 +69,43 @@ func serviceAccountFromDefaultCredentials(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	var credentials struct {
-		Type        string `json:"type"`
-		ClientEmail string `json:"client_email"`
+		Type                           string `json:"type"`
+		ClientEmail                    string `json:"client_email"`
+		ServiceAccountImpersonationURL string `json:"service_account_impersonation_url"`
 	}
 	if err := json.Unmarshal(defaultCredentials.JSON, &credentials); err != nil {
 		return "", false
 	}
-	if credentials.Type != "service_account" {
-		return "", false
+	switch credentials.Type {
+	case "service_account":
+		return credentials.ClientEmail, credentials.ClientEmail != ""
+	case "impersonated_service_account":
+		sa, err := extractServiceAccountFromImpersonationURL(credentials.ServiceAccountImpersonationURL)
+		if err != nil {
+			return "", false
+		}
+		return sa, true
 	}
-	return credentials.ClientEmail, credentials.ClientEmail != ""
+	return "", false
+}
+
+// extractServiceAccountFromImpersonationURL parses a URL like
+// ".../serviceAccounts/sa@project.iam.gserviceaccount.com:generateAccessToken"
+// and returns "sa@project.iam.gserviceaccount.com".
+func extractServiceAccountFromImpersonationURL(urlStr string) (string, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(u.Path, "/")
+	for i, part := range parts {
+		if part == "serviceAccounts" && i+1 < len(parts) {
+			sa := parts[i+1]
+			if idx := strings.Index(sa, ":"); idx != -1 {
+				sa = sa[:idx]
+			}
+			return sa, nil
+		}
+	}
+	return "", fmt.Errorf("service account not found in URL")
 }


### PR DESCRIPTION
In a case when impersonated credentials are used to run the service, cloudruntime fails to extract the service account email from the file because it's stored a little differentely.

I think this is a nice addition, specifically for the `LocalDevelop` workflow.