### PR TITLE
fix(cloudzap): user service field (not name field)

### DIFF
--- a/cloudzap/errorreport.go
+++ b/cloudzap/errorreport.go
@@ -39,18 +39,18 @@ func ErrorReportContext(file string, line int, function string) zapcore.Field {
 // ErrorReportServiceContext returns a structured logging field for error report context for the provided caller.
 func ErrorReportServiceContext(serviceName, serviceVersion string) zapcore.Field {
 	return zap.Object(errorReportServiceContextKey, errorReportServiceContext{
-		name:    serviceName,
+		service: serviceName,
 		version: serviceVersion,
 	})
 }
 
 type errorReportServiceContext struct {
-	name    string
+	service string
 	version string
 }
 
 func (s errorReportServiceContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
-	encoder.AddString("name", s.name)
+	encoder.AddString("service", s.service)
 	encoder.AddString("version", s.version)
 	return nil
 }


### PR DESCRIPTION
### Why?

- It seems we are recording the service name into the wrong field for cloudzap. See schema at
https://cloud.google.com/error-reporting/docs/formatting-error-messages#reported-error-example

### What?

- Rename the field we set from `name` to `service`, to match what the schema says in the docs.

### Notes

- Might be risky/unnecessary to do changes here now. We are planning on removing cloudzap support.