### PR TITLE
feat(cloudslog): store httpRequest, if available

### DIFF
--- a/cloudrequestlog/middleware.go
+++ b/cloudrequestlog/middleware.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"go.einride.tech/cloudrunner/cloudslog"
 	"go.einride.tech/cloudrunner/cloudstream"
 	ltype "google.golang.org/genproto/googleapis/logging/type"
 	"google.golang.org/grpc"
@@ -32,6 +33,7 @@ func (l *Middleware) GRPCUnaryServerInterceptor(
 ) (interface{}, error) {
 	startTime := time.Now()
 	ctx = WithAdditionalFields(ctx)
+	ctx = cloudslog.WithHTTPRequest(ctx, &ltype.HttpRequest{Protocol: "gRPC"})
 	// Clone request to ensure not using a mutated one later
 	requestClone := proto.Clone(request.(proto.Message))
 	response, err := handler(ctx, request)
@@ -84,6 +86,7 @@ func (l *Middleware) GRPCStreamServerInterceptor(
 ) error {
 	startTime := time.Now()
 	ctx := WithAdditionalFields(ss.Context())
+	ctx = cloudslog.WithHTTPRequest(ctx, &ltype.HttpRequest{Protocol: "gRPC"})
 	ss = cloudstream.NewContextualServerStream(ctx, ss)
 	err := handler(srv, ss)
 	responseStatus := status.Convert(err)
@@ -190,6 +193,17 @@ func (l *Middleware) HTTPServer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		ctx := WithAdditionalFields(r.Context())
+		httpReq := &ltype.HttpRequest{
+			RequestMethod: r.Method,
+			UserAgent:     r.UserAgent(),
+			RemoteIp:      r.RemoteAddr,
+			Referer:       r.Referer(),
+			Protocol:      r.Proto,
+		}
+		if r.URL != nil {
+			httpReq.RequestUrl = r.URL.String()
+		}
+		ctx = cloudslog.WithHTTPRequest(ctx, httpReq)
 		r = r.WithContext(ctx)
 		responseWriter := &httpResponseWriter{ResponseWriter: w}
 		next.ServeHTTP(responseWriter, r)

--- a/cloudslog/handler.go
+++ b/cloudslog/handler.go
@@ -85,9 +85,9 @@ func (t *handler) Handle(ctx context.Context, record slog.Record) error {
 			}
 		}
 
-		// Build context group with optional httpRequest and reportLocation
-		contextAttrs := []any{}
-		if httpRequest := t.extractHTTPRequest(record); httpRequest != nil {
+		// Build context group with optional httpRequest and reportLocation.
+		var contextAttrs []any
+		if httpRequest := httpRequestFromContext(ctx); httpRequest != nil {
 			contextAttrs = append(contextAttrs, slog.Any("httpRequest", httpRequest))
 		}
 		if record.PC != 0 {
@@ -105,20 +105,6 @@ func (t *handler) Handle(ctx context.Context, record slog.Record) error {
 	}
 	record.AddAttrs(attributesFromContext(ctx)...)
 	return t.Handler.Handle(ctx, record)
-}
-
-// extractHTTPRequest extracts the httpRequest attribute from the log record if present.
-// The httpRequest is added by the request logging middleware in cloudrequestlog/middleware.go.
-func (t *handler) extractHTTPRequest(record slog.Record) *ltype.HttpRequest {
-	var httpRequest *ltype.HttpRequest
-	record.Attrs(func(a slog.Attr) bool {
-		if a.Key == "httpRequest" {
-			httpRequest, _ = a.Value.Any().(*ltype.HttpRequest)
-			return false
-		}
-		return true
-	})
-	return httpRequest
 }
 
 type attrReplacer struct {

--- a/cloudslog/handler.go
+++ b/cloudslog/handler.go
@@ -85,20 +85,40 @@ func (t *handler) Handle(ctx context.Context, record slog.Record) error {
 			}
 		}
 
+		// Build context group with optional httpRequest and reportLocation
+		contextAttrs := []any{}
+		if httpRequest := t.extractHTTPRequest(record); httpRequest != nil {
+			contextAttrs = append(contextAttrs, slog.Any("httpRequest", httpRequest))
+		}
 		if record.PC != 0 {
 			fs := runtime.CallersFrames([]uintptr{record.PC})
 			f, _ := fs.Next()
-			record.AddAttrs(slog.Group("context",
-				slog.Group("reportLocation",
-					slog.String("filePath", f.File),
-					slog.Int("lineNumber", f.Line),
-					slog.String("functionName", f.Function),
-				),
+			contextAttrs = append(contextAttrs, slog.Group("reportLocation",
+				slog.String("filePath", f.File),
+				slog.Int("lineNumber", f.Line),
+				slog.String("functionName", f.Function),
 			))
+		}
+		if len(contextAttrs) > 0 {
+			record.AddAttrs(slog.Group("context", contextAttrs...))
 		}
 	}
 	record.AddAttrs(attributesFromContext(ctx)...)
 	return t.Handler.Handle(ctx, record)
+}
+
+// extractHTTPRequest extracts the httpRequest attribute from the log record if present.
+// The httpRequest is added by the request logging middleware in cloudrequestlog/middleware.go.
+func (t *handler) extractHTTPRequest(record slog.Record) *ltype.HttpRequest {
+	var httpRequest *ltype.HttpRequest
+	record.Attrs(func(a slog.Attr) bool {
+		if a.Key == "httpRequest" {
+			httpRequest, _ = a.Value.Any().(*ltype.HttpRequest)
+			return false
+		}
+		return true
+	})
+	return httpRequest
 }
 
 type attrReplacer struct {

--- a/cloudslog/httprequest_context.go
+++ b/cloudslog/httprequest_context.go
@@ -1,0 +1,21 @@
+package cloudslog
+
+import (
+	"context"
+
+	ltype "google.golang.org/genproto/googleapis/logging/type"
+)
+
+type httpRequestContextKey struct{}
+
+// WithHTTPRequest stores an [ltype.HttpRequest] on the context for use in error reporting.
+// This should be called by request middleware before handling the request, so that
+// error reports logged during request handling can include HTTP request context.
+func WithHTTPRequest(parent context.Context, req *ltype.HttpRequest) context.Context {
+	return context.WithValue(parent, httpRequestContextKey{}, req)
+}
+
+func httpRequestFromContext(ctx context.Context) *ltype.HttpRequest {
+	req, _ := ctx.Value(httpRequestContextKey{}).(*ltype.HttpRequest)
+	return req
+}

--- a/cloudslog/httprequest_context_test.go
+++ b/cloudslog/httprequest_context_test.go
@@ -1,0 +1,49 @@
+package cloudslog
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	ltype "google.golang.org/genproto/googleapis/logging/type"
+	"gotest.tools/v3/assert"
+)
+
+func TestHandler_httpRequestFromContext(t *testing.T) {
+	t.Run("included in error report context", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{ReportErrors: true}))
+		ctx := WithHTTPRequest(context.Background(), &ltype.HttpRequest{
+			RequestMethod: "GET",
+			RequestUrl:    "/test/path",
+			UserAgent:     "test-agent",
+		})
+		logger.ErrorContext(ctx, "something went wrong")
+		got := b.String()
+		assert.Assert(t, strings.Contains(got, `"requestMethod":"GET"`), got)
+		assert.Assert(t, strings.Contains(got, `"requestUrl":"/test/path"`), got)
+		assert.Assert(t, strings.Contains(got, `"userAgent":"test-agent"`), got)
+	})
+
+	t.Run("not included when no httpRequest on context", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{ReportErrors: true}))
+		logger.ErrorContext(context.Background(), "something went wrong")
+		got := b.String()
+		assert.Assert(t, !strings.Contains(got, `"httpRequest"`), got)
+	})
+
+	t.Run("not included for non-error levels", func(t *testing.T) {
+		var b strings.Builder
+		logger := slog.New(newHandler(&b, LoggerConfig{ReportErrors: true}))
+		ctx := WithHTTPRequest(context.Background(), &ltype.HttpRequest{
+			RequestMethod: "GET",
+			RequestUrl:    "/test/path",
+		})
+		logger.InfoContext(ctx, "just info")
+		got := b.String()
+		// httpRequest should not appear in the context group for non-error logs.
+		assert.Assert(t, !strings.Contains(got, `"httpRequest"`), got)
+	})
+}


### PR DESCRIPTION
### Why?

There are additional fields we could put onto the error report. See
`context.httpRequest` part of the [schema](https://cloud.google.com/error-reporting/docs/formatting-error-messages#reported-error-example).

The request logging middleware currently only sets `httpRequest` on the record
*after* the handler returns (for access logging). This means errors logged
during request handling never have `httpRequest` available for error reports.

### What?

- Add a dedicated context key (`cloudslog.WithHTTPRequest`) to store a partial
  `httpRequest` on the context *before* request handling begins.
- The error reporting handler reads from this context key to include
  `httpRequest` in the error report's `context` group.
- The middleware (`cloudrequestlog`) sets the partial `httpRequest` on the
  context in all server-side entry points (gRPC unary, gRPC stream, HTTP).
- The access log continues to build its own full `httpRequest` (with status,
  latency, response size) as a record attribute after the handler returns —
  no duplication or interference.

### Notes

cc @ngalaiko — addressed your [feedback](https://github.com/einride/cloudrunner-go/pull/813#issuecomment-3500944995)
about the timing issue by using a context-based approach.