### PR TITLE
feat: configurable http server shutdown time

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ cloudrunner    METRICEXPORTER_DROPMETRICS               []string
 cloudrunner    RESOURCE_ALLOWPARTIALRESOURCE            bool                                                
 cloudrunner    RESOURCE_ALLOWSCHEMAURLCONFLICT          bool                                                
 cloudrunner    SERVER_TIMEOUT                           time.Duration                290s                   
+cloudrunner    SERVER_SHUTDOWNTIMEOUT                   time.Duration                5s                     
 cloudrunner    CLIENT_TIMEOUT                           time.Duration                10s                    
 cloudrunner    CLIENT_RETRY_ENABLED                     bool                         true                   
 cloudrunner    CLIENT_RETRY_INITIALBACKOFF              time.Duration                200ms                  

--- a/cloudmux/mux.go
+++ b/cloudmux/mux.go
@@ -15,6 +15,21 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Option configures ServeGRPCHTTP.
+type Option func(*muxConfig)
+
+type muxConfig struct {
+	shutdownTimeout time.Duration
+}
+
+// WithShutdownTimeout sets the maximum duration to wait for in-flight requests
+// to complete during graceful shutdown. Defaults to 5s.
+func WithShutdownTimeout(d time.Duration) Option {
+	return func(c *muxConfig) {
+		c.shutdownTimeout = d
+	}
+}
+
 // ServeGRPCHTTP serves both a gRPC and an HTTP server on listener l.
 // When the context is canceled, the servers will be gracefully shutdown and
 // then the function will return.
@@ -23,7 +38,12 @@ func ServeGRPCHTTP(
 	l net.Listener,
 	grpcServer *grpc.Server,
 	httpServer *http.Server,
+	opts ...Option,
 ) error {
+	cfg := muxConfig{shutdownTimeout: 5 * time.Second}
+	for _, o := range opts {
+		o(&cfg)
+	}
 	m := cmux.New(l)
 	grpcL := m.MatchWithWriters(
 		cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"),
@@ -38,7 +58,7 @@ func ServeGRPCHTTP(
 		m.Close()
 		slog.DebugContext(ctx, "stopping HTTP server")
 		// use a new context because the parent ctx is already canceled.
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.shutdownTimeout)
 		defer cancel()
 		if err := httpServer.Shutdown(ctx); err != nil && !isClosedErr(err) {
 			slog.WarnContext(ctx, "stopping http server", slog.Any("error", err))

--- a/cloudserver/config.go
+++ b/cloudserver/config.go
@@ -9,4 +9,7 @@ type Config struct {
 	// Timeout of all requests to the servers.
 	// Defaults to 10 seconds below the default Cloud Run timeout for managed services.
 	Timeout time.Duration `default:"290s"`
+	// ShutdownTimeout is the maximum duration to wait for in-flight requests
+	// to complete during graceful shutdown.
+	ShutdownTimeout time.Duration `default:"5s"`
 }

--- a/httpserver.go
+++ b/httpserver.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"go.einride.tech/cloudrunner/cloudserver"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -79,13 +78,18 @@ func httpSpanName(_ string, r *http.Request) string {
 
 // ListenHTTP binds a listener on the configured port and listens for HTTP requests.
 func ListenHTTP(ctx context.Context, httpServer *http.Server) error {
+	run, ok := getRunContext(ctx)
+	if !ok {
+		return fmt.Errorf("cloudrunner.ListenHTTP: must be called with a context from cloudrunner.Run")
+	}
+	shutdownTimeout := run.serverMiddleware.Config.ShutdownTimeout
 	shutdown := make(chan struct{})
 	//nolint:gosec // G118: intentional use of context.Background for graceful shutdown after parent context cancellation
 	go func() {
 		<-ctx.Done()
 		slog.InfoContext(ctx, "HTTPServer shutting down")
 
-		shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownContext, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 
 		httpServer.SetKeepAlivesEnabled(false)

--- a/muxserver.go
+++ b/muxserver.go
@@ -16,7 +16,7 @@ func ListenGRPCHTTP(ctx context.Context, grpcServer *grpc.Server, httpServer *ht
 	if !ok {
 		return fmt.Errorf("cloudrunner.ListenGRPCHTTP: must be called with a context from cloudrunner.Run")
 	}
-	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", Runtime(ctx).Port))
+	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", run.config.Runtime.Port))
 	if err != nil {
 		return fmt.Errorf("serve gRPC and HTTP: %w", err)
 	}

--- a/muxserver.go
+++ b/muxserver.go
@@ -12,11 +12,18 @@ import (
 
 // ListenGRPCHTTP binds a listener on the configured port and listens for gRPC and HTTP requests.
 func ListenGRPCHTTP(ctx context.Context, grpcServer *grpc.Server, httpServer *http.Server) error {
+	run, ok := getRunContext(ctx)
+	if !ok {
+		return fmt.Errorf("cloudrunner.ListenGRPCHTTP: must be called with a context from cloudrunner.Run")
+	}
 	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", Runtime(ctx).Port))
 	if err != nil {
 		return fmt.Errorf("serve gRPC and HTTP: %w", err)
 	}
-	if err := cloudmux.ServeGRPCHTTP(ctx, l, grpcServer, httpServer); err != nil {
+	if err := cloudmux.ServeGRPCHTTP(
+		ctx, l, grpcServer, httpServer,
+		cloudmux.WithShutdownTimeout(run.serverMiddleware.Config.ShutdownTimeout),
+	); err != nil {
 		return fmt.Errorf("serve gRPC and HTTP: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Remove the hardcoded 5s and introduce a configurable setting that defaults to 5s.