### PR TITLE
chore: add dependabot cooldown settings to mitigate ongoing supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
 
     cooldown:
       default-days: 7
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -22,7 +26,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
-
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directory: .sage
     schedule:
@@ -32,3 +39,7 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*


### PR DESCRIPTION
## Summary

Adds `cooldown` configuration to every package ecosystem in `.github/dependabot.yml` to reduce exposure to ongoing supply chain attacks by limiting how quickly compromised or malicious package versions can be automatically adopted.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
  exclude:
    - github.com/einride/*
    - github.com/einride-autonomous/*
    - github.com/einride-labs/*
```

Security updates are automatically exempt from this cooldown.
