### PR TITLE
fix: make WrapTransient preserve Aborted errors

### DIFF
--- a/clouderror/wrap.go
+++ b/clouderror/wrap.go
@@ -38,7 +38,7 @@ func WrapTransient(err error, msg string) error {
 func WrapTransientCaller(err error, msg string, caller Caller) error {
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() {
-		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Aborted:
 			return &wrappedStatusError{status: status.New(s.Code(), msg), err: err, caller: caller}
 		}
 	}


### PR DESCRIPTION
Aborted is documented in gRPC as:
> The operation was aborted, typically due to a concurrency issue such as a sequencer check failure or transaction abort

I.e. retrying will often solve the issue, and thus it can be considered retryable/transient and should be preserved by this function.
