### PR TITLE
fix: allow dropping metrics in otelhttp and otelgrpc

### DIFF
--- a/cloudotel/metricexporter.go
+++ b/cloudotel/metricexporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	ocbridge "go.opentelemetry.io/otel/bridge/opencensus"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
@@ -66,15 +66,22 @@ func StartMetricExporter(
 	// The following views masks these attributes from both otelhttp and otelgrpc so
 	// that metrics can still be exported.
 	// Based on https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3071#issuecomment-1416137206
+	//
+	// IMPORTANT: a drop view (DropMetrics) and a scope-based attribute mask view are combined into a single
+	// View function per scope. If they were registered as two separate sdkmetric.View entries, an instrument
+	// matching both would produce two independent output streams — the drop aggregation on one stream does NOT
+	// suppress the other, unmasked stream still being exported.
 	views := []sdkmetric.View{
-		maskInstrumentAttrs(
+		maskedView(
 			"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+			exporterConfig.DropMetrics,
 			semconv.NetPeerPortKey,
 			semconv.NetSockPeerPortKey,
 			attribute.Key("http.client_ip"),
 		),
-		maskInstrumentAttrs(
+		maskedView(
 			"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
+			exporterConfig.DropMetrics,
 			semconv.NetPeerPortKey,
 			semconv.NetSockPeerPortKey,
 		),
@@ -128,18 +135,52 @@ func dropMetricView(name string) sdkmetric.View {
 	)
 }
 
-func maskInstrumentAttrs(instrumentScopeName string, attrs ...attribute.Key) sdkmetric.View {
-	masked := make(map[attribute.Key]struct{})
-	for _, attr := range attrs {
-		masked[attr] = struct{}{}
+// maskedView returns a View for the given instrumentation scope that drops any instrument whose name
+// matches one of dropPatterns (glob patterns, e.g. "http.client.*"), and otherwise masks the given attributes.
+func maskedView(scopeName string, dropPatterns []string, maskedAttrs ...attribute.Key) sdkmetric.View {
+	masked := make(map[attribute.Key]struct{}, len(maskedAttrs))
+	for _, a := range maskedAttrs {
+		masked[a] = struct{}{}
 	}
-	return sdkmetric.NewView(
-		sdkmetric.Instrument{Scope: instrumentation.Scope{Name: instrumentScopeName}},
-		sdkmetric.Stream{
+	return func(inst sdkmetric.Instrument) (sdkmetric.Stream, bool) {
+		if inst.Scope.Name != scopeName {
+			// does not match scope - view does not apply
+			return sdkmetric.Stream{}, false
+		}
+		if matchesAnyMetricPattern(inst.Name, dropPatterns) {
+			// matches drop pattern - drop the metric
+			return sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}}, true
+		}
+		// matches scope but should not be dropped - mask the attributes
+		return sdkmetric.Stream{
+			Name:        inst.Name,
+			Description: inst.Description,
+			Unit:        inst.Unit,
 			AttributeFilter: func(value attribute.KeyValue) bool {
 				_, ok := masked[value.Key]
 				return !ok
 			},
-		},
-	)
+		}, true
+	}
+}
+
+func matchesAnyMetricPattern(name string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if matchesMetricPattern(name, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// taken from https://github.com/open-telemetry/opentelemetry-go/blob/7dd91016c5768fa8e4d1835ccbd9774f4ff75b71/sdk/metric/view.go#L71
+//
+//nolint:lll
+func matchesMetricPattern(name, patternString string) bool {
+	pattern := regexp.QuoteMeta(patternString)
+	pattern = "^" + pattern + "$"
+	pattern = strings.ReplaceAll(pattern, `\?`, ".")
+	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(name)
 }

--- a/cloudotel/metricexporter_test.go
+++ b/cloudotel/metricexporter_test.go
@@ -3,6 +3,8 @@ package cloudotel
 import (
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"gotest.tools/v3/assert"
@@ -119,4 +121,131 @@ func TestDropMetricView(t *testing.T) {
 		}
 		assert.DeepEqual(t, metricNames, []string{"test.kept.counter"})
 	})
+}
+
+func TestMaskedView(t *testing.T) {
+	t.Run("masks configured attributes for matching scope", func(t *testing.T) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithView(maskedView("test.scope", nil, attribute.Key("masked"))),
+		)
+		meter := provider.Meter("test.scope")
+		counter, err := meter.Int64Counter("test.counter")
+		assert.NilError(t, err)
+
+		ctx := t.Context()
+		counter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("masked", "value"),
+			attribute.String("kept", "value"),
+		))
+
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(ctx, &rm)
+		assert.NilError(t, err)
+
+		attrs := dataPointAttributes(t, rm, "test.counter")
+		assert.Assert(t, !attrs.HasValue("masked"))
+		assert.Assert(t, attrs.HasValue("kept"))
+	})
+
+	t.Run("does not mask attributes for a non-matching scope", func(t *testing.T) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithView(maskedView("other.scope", nil, attribute.Key("masked"))),
+		)
+		meter := provider.Meter("test.scope")
+		counter, err := meter.Int64Counter("test.counter")
+		assert.NilError(t, err)
+
+		ctx := t.Context()
+		counter.Add(ctx, 1, metric.WithAttributes(attribute.String("masked", "value")))
+
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(ctx, &rm)
+		assert.NilError(t, err)
+
+		attrs := dataPointAttributes(t, rm, "test.counter")
+		assert.Assert(t, attrs.HasValue("masked"))
+	})
+
+	t.Run("drops metrics matching a drop pattern within the scope", func(t *testing.T) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithView(maskedView("test.scope", []string{"test.dropped.*"}, attribute.Key("masked"))),
+		)
+		meter := provider.Meter("test.scope")
+		dropped, err := meter.Int64Counter("test.dropped.counter")
+		assert.NilError(t, err)
+		kept, err := meter.Int64Counter("test.kept.counter")
+		assert.NilError(t, err)
+
+		ctx := t.Context()
+		dropped.Add(ctx, 10)
+		kept.Add(ctx, 20)
+
+		var rm metricdata.ResourceMetrics
+		err = reader.Collect(ctx, &rm)
+		assert.NilError(t, err)
+
+		var metricNames []string
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				metricNames = append(metricNames, m.Name)
+			}
+		}
+		assert.DeepEqual(t, metricNames, []string{"test.kept.counter"})
+	})
+}
+
+func TestMaskedViewAndDropMetricView(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(
+			maskedView("test.scope", []string{"test.counter"}, attribute.Key("masked")),
+			dropMetricView("test.counter"),
+		),
+	)
+	meter := provider.Meter("test.scope")
+	counter, err := meter.Int64Counter("test.counter")
+	assert.NilError(t, err)
+
+	ctx := t.Context()
+	counter.Add(ctx, 1, metric.WithAttributes(attribute.String("masked", "value")))
+
+	var rm metricdata.ResourceMetrics
+	err = reader.Collect(ctx, &rm)
+	assert.NilError(t, err)
+
+	var metricNames []string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			metricNames = append(metricNames, m.Name)
+		}
+	}
+	assert.DeepEqual(t, metricNames, []string(nil))
+}
+
+// dataPointAttributes returns the attribute set of the single data point recorded
+// for the metric with the given name, failing the test if it is missing or ambiguous.
+func dataPointAttributes(t *testing.T, rm metricdata.ResourceMetrics, metricName string) attribute.Set {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != metricName {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok || len(sum.DataPoints) != 1 {
+				t.Fatalf("dataPointAttributes(%q) = metric with unexpected data %#v, want a single int64 sum point",
+					metricName, m.Data)
+			}
+			return sum.DataPoints[0].Attributes
+		}
+	}
+	t.Fatalf("dataPointAttributes(%q) = not found", metricName)
+	return attribute.Set{}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/bridge/opencensus v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
@@ -68,7 +69,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect


### PR DESCRIPTION
Before this PR, the METRICEXPORTER_DROPMETRICS configuration flag did not work for metrics in the otelhttp and otelgrpc scopes.
The reason being that hardcoded otel [views](https://github.com/open-telemetry/opentelemetry-go/blob/7dd91016c5768fa8e4d1835ccbd9774f4ff75b71/sdk/metric/view.go#L29) are added for the otelhttp and otelgrpc scopes, these views remove a hardcoded list of known high-cardinality attributes. The way otel is written, if multiple views match a single metric, whichever view was registered first will "win". The hardcoded views are registered before the drop view and so the drop view will not be applied to metrics in the otelhttp and otelgrpc scopes.

To solve this, change the hardcoded views so that they, in addition to dropping high-cardinality attributes, also drop any metrics matching patterns specified in METRICEXPORTER_DROPMETRICS. The function for matching a metric name against a wildcard pattern is not exported in otel, so the code is copied into this repo.